### PR TITLE
Hotfix 235 custom post type permalinks plugin

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -240,7 +240,7 @@ There is no big company behind this software, besides a sole proprietership in m
 
 Help keep me doing what I love: building and supporting this software. 
 
- - [Buy the PowerPack](https://wp2static.com)
+ - [Buy a commercial license](https://wp2static.com)
  - [Back me on Patreon](https://www.patreon.com/leonstafford)
  - [Fund my PayPal](https://www.paypal.me/leonjstafford)
 

--- a/languages/static-html-output-plugin.pot
+++ b/languages/static-html-output-plugin.pot
@@ -1,7 +1,7 @@
 # WP Static HTML Output
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Static Site Generator 6.4\n"
+"Project-Id-Version: WP Static Site Generator 6.5\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wp-static-html-output\n"
 "POT-Creation-Date: 2018-04-25 14:34:12+00:00\n"

--- a/library/StaticHtmlOutput.php
+++ b/library/StaticHtmlOutput.php
@@ -1,7 +1,7 @@
 <?php
 
 class StaticHtmlOutput_Controller {
-    const VERSION = '6.5-dev';
+    const VERSION = '6.5';
     const OPTIONS_KEY = 'wp2static-options';
     const HOOK = 'wp2static';
 

--- a/library/StaticHtmlOutput.php
+++ b/library/StaticHtmlOutput.php
@@ -1,7 +1,7 @@
 <?php
 
 class StaticHtmlOutput_Controller {
-    const VERSION = '6.4';
+    const VERSION = '6.5-dev';
     const OPTIONS_KEY = 'wp2static-options';
     const HOOK = 'wp2static';
 

--- a/library/StaticHtmlOutput/FilesHelper.php
+++ b/library/StaticHtmlOutput/FilesHelper.php
@@ -540,21 +540,25 @@ class StaticHtmlOutput_FilesHelper {
 
             foreach ( $terms as $term ) {
                 $permalink = trim( get_term_link( $term ) );
+                $total_posts = $term->count;
 
-                $category_links[] = str_replace(
+                $term_url =  str_replace(
                     $wp_site_url,
                     '',
                     $permalink
                 );
 
+                $category_links[$term_url] = $total_posts;
+
                 $post_urls[] = $permalink;
             }
         }
 
-        // TODO: do get the pagination for these, too:
-        // $category_links;
+        // get all pagination links for each category
+        $category_pagination_urls =
+            self::getPaginationURLsForCategories( $category_links );
 
-        // get all pagination links for each taxonomy
+        // get all pagination links for each post_type
         $post_pagination_urls =
             self::getPaginationURLsForPosts(
                 array_unique( $unique_post_types )
@@ -562,7 +566,8 @@ class StaticHtmlOutput_FilesHelper {
 
         $post_urls = array_merge(
             $post_urls,
-            $post_pagination_urls
+            $post_pagination_urls,
+            $category_pagination_urls
         );
 
         return array_unique( $post_urls );
@@ -604,6 +609,25 @@ class StaticHtmlOutput_FilesHelper {
                     "/{$plural_form}/{$pagination_base}/{$page}";
             }
 
+        }
+
+        return $urls_to_include;
+    }
+
+    public static function getPaginationURLsForCategories( $categories ) {
+        global $wp_rewrite;
+
+        $urls_to_include = array();
+        $pagination_base = $wp_rewrite->pagination_base;
+        $default_posts_per_page = get_option( 'posts_per_page' );
+
+        foreach ( $categories as $term => $total_posts ) {
+            $total_pages = ceil( $total_posts / $default_posts_per_page );
+
+            for( $page = 1; $page <= $total_pages; $page++ ) {
+                $urls_to_include[] =
+                    "{$term}/{$pagination_base}/{$page}";
+            }
         }
 
         return $urls_to_include;

--- a/library/StaticHtmlOutput/FilesHelper.php
+++ b/library/StaticHtmlOutput/FilesHelper.php
@@ -442,7 +442,7 @@ class StaticHtmlOutput_FilesHelper {
         global $wpdb;
 
         $post_urls = array();
-        $unique_taxonomies = array();
+        $unique_post_types = array();
 
         $query = "
             SELECT ID,post_type
@@ -464,7 +464,7 @@ class StaticHtmlOutput_FilesHelper {
         foreach ( $posts as $post ) {
             // capture all post types
             if ( $post->post_type !== 'wpcf7_contact_form' ) {
-                $unique_taxonomies[] = $post->post_type;
+                $unique_post_types[] = $post->post_type;
             }
 
             switch ( $post->post_type ) {
@@ -557,7 +557,7 @@ class StaticHtmlOutput_FilesHelper {
         // get all pagination links for each taxonomy
         $post_pagination_urls =
             self::getPaginationURLsForPosts(
-                array_unique( $unique_taxonomies )
+                array_unique( $unique_post_types )
         );
 
         $post_urls = array_merge(
@@ -568,7 +568,7 @@ class StaticHtmlOutput_FilesHelper {
         return array_unique( $post_urls );
     }
 
-    public static function getPaginationURLsForPosts( $taxonomies ) {
+    public static function getPaginationURLsForPosts( $post_types ) {
         global $wpdb, $wp_rewrite;
 
         $pagination_base = $wp_rewrite->pagination_base;
@@ -576,7 +576,7 @@ class StaticHtmlOutput_FilesHelper {
 
         $urls_to_include = array();
 
-        foreach( $taxonomies as $taxonomy) {
+        foreach( $post_types as $post_type) {
             $query = "
                 SELECT ID,post_type
                 FROM %s
@@ -588,12 +588,12 @@ class StaticHtmlOutput_FilesHelper {
                     $query,
                     $wpdb->posts,
                     'publish',
-                    $taxonomy
+                    $post_type
                 )
             );
 
-            $post_type = get_post_type_object( $taxonomy );
-            $plural_form = strtolower( $post_type->labels->name );
+            $post_type_obj = get_post_type_object( $post_type );
+            $plural_form = strtolower( $post_type_obj->labels->name );
 
             $count = $wpdb->num_rows;
 

--- a/library/StaticHtmlOutput/FilesHelper.php
+++ b/library/StaticHtmlOutput/FilesHelper.php
@@ -460,7 +460,6 @@ class StaticHtmlOutput_FilesHelper {
             )
         );
 
-
         foreach ( $posts as $post ) {
             // capture all post types
             if ( $post->post_type !== 'wpcf7_contact_form' ) {
@@ -542,13 +541,13 @@ class StaticHtmlOutput_FilesHelper {
                 $permalink = trim( get_term_link( $term ) );
                 $total_posts = $term->count;
 
-                $term_url =  str_replace(
+                $term_url = str_replace(
                     $wp_site_url,
                     '',
                     $permalink
                 );
 
-                $category_links[$term_url] = $total_posts;
+                $category_links[ $term_url ] = $total_posts;
 
                 $post_urls[] = $permalink;
             }
@@ -562,7 +561,7 @@ class StaticHtmlOutput_FilesHelper {
         $post_pagination_urls =
             self::getPaginationURLsForPosts(
                 array_unique( $unique_post_types )
-        );
+            );
 
         // get all comment links
         $comment_pagination_urls =
@@ -586,7 +585,7 @@ class StaticHtmlOutput_FilesHelper {
 
         $urls_to_include = array();
 
-        foreach( $post_types as $post_type) {
+        foreach ( $post_types as $post_type ) {
             $query = "
                 SELECT ID,post_type
                 FROM %s
@@ -609,11 +608,10 @@ class StaticHtmlOutput_FilesHelper {
 
             $total_pages = ceil( $count / $default_posts_per_page );
 
-            for( $page = 1; $page <= $total_pages; $page++ ) {
+            for ( $page = 1; $page <= $total_pages; $page++ ) {
                 $urls_to_include[] =
                     "/{$plural_form}/{$pagination_base}/{$page}";
             }
-
         }
 
         return $urls_to_include;
@@ -629,7 +627,7 @@ class StaticHtmlOutput_FilesHelper {
         foreach ( $categories as $term => $total_posts ) {
             $total_pages = ceil( $total_posts / $default_posts_per_page );
 
-            for( $page = 1; $page <= $total_pages; $page++ ) {
+            for ( $page = 1; $page <= $total_pages; $page++ ) {
                 $urls_to_include[] =
                     "{$term}/{$pagination_base}/{$page}";
             }
@@ -644,11 +642,11 @@ class StaticHtmlOutput_FilesHelper {
         $urls_to_include = array();
         $comments_pagination_base = $wp_rewrite->comments_pagination_base;
 
-        foreach( get_comments() as $comment ) {
+        foreach ( get_comments() as $comment ) {
             $comment_url = get_comment_link( $comment->comment_ID );
             $comment_url = strtok( $comment_url, '#' );
 
-            $urls_to_include[] =  str_replace(
+            $urls_to_include[] = str_replace(
                 $wp_site_url,
                 '',
                 $comment_url

--- a/library/StaticHtmlOutput/FilesHelper.php
+++ b/library/StaticHtmlOutput/FilesHelper.php
@@ -556,9 +556,14 @@ class StaticHtmlOutput_FilesHelper {
 
         // get all pagination links for each taxonomy
         $post_pagination_urls =
-            self::getPaginationURLsForPosts( array_unique( $unique_taxonomies ) );
+            self::getPaginationURLsForPosts(
+                array_unique( $unique_taxonomies )
+        );
 
-        // TODO: merge arrays
+        $post_urls = array_merge(
+            $post_urls,
+            $post_pagination_urls
+        );
 
         return array_unique( $post_urls );
     }
@@ -569,14 +574,9 @@ class StaticHtmlOutput_FilesHelper {
         $pagination_base = $wp_rewrite->pagination_base;
         $default_posts_per_page = get_option( 'posts_per_page' );
 
-        error_log($pagination_base);
-        error_log($default_posts_per_page);
-
-
         $urls_to_include = array();
 
         foreach( $taxonomies as $taxonomy) {
-            // TODO: run query to get total, divide by 
             $query = "
                 SELECT ID,post_type
                 FROM %s
@@ -594,10 +594,16 @@ class StaticHtmlOutput_FilesHelper {
 
             $count = $wpdb->num_rows;
 
-            error_log($count . ': ' . $taxonomy);
+            $total_pages = ceil( $count / $default_posts_per_page );
+
+            for( $page = 1; $page <= $total_pages; $page++ ) {
+                $urls_to_include[] =
+                    "/{$taxonomy}/{$pagination_base}/{$page}";
+            }
+
         }
 
-        error_log(print_r( $taxonomies, true));die();
+        return $urls_to_include;
     }
 }
 

--- a/library/StaticHtmlOutput/FilesHelper.php
+++ b/library/StaticHtmlOutput/FilesHelper.php
@@ -564,10 +564,15 @@ class StaticHtmlOutput_FilesHelper {
                 array_unique( $unique_post_types )
         );
 
+        // get all comment links
+        $comment_pagination_urls =
+            self::getPaginationURLsForComments( $wp_site_url );
+
         $post_urls = array_merge(
             $post_urls,
             $post_pagination_urls,
-            $category_pagination_urls
+            $category_pagination_urls,
+            $comment_pagination_urls
         );
 
         return array_unique( $post_urls );
@@ -631,6 +636,26 @@ class StaticHtmlOutput_FilesHelper {
         }
 
         return $urls_to_include;
+    }
+
+    public static function getPaginationURLsForComments( $wp_site_url ) {
+        global $wp_rewrite;
+
+        $urls_to_include = array();
+        $comments_pagination_base = $wp_rewrite->comments_pagination_base;
+
+        foreach( get_comments() as $comment ) {
+            $comment_url = get_comment_link( $comment->comment_ID );
+            $comment_url = strtok( $comment_url, '#' );
+
+            $urls_to_include[] =  str_replace(
+                $wp_site_url,
+                '',
+                $comment_url
+            );
+        }
+
+        return array_unique( $urls_to_include );
     }
 }
 

--- a/library/StaticHtmlOutput/FilesHelper.php
+++ b/library/StaticHtmlOutput/FilesHelper.php
@@ -592,13 +592,16 @@ class StaticHtmlOutput_FilesHelper {
                 )
             );
 
+            $post_type = get_post_type_object( $taxonomy );
+            $plural_form = strtolower( $post_type->labels->name );
+
             $count = $wpdb->num_rows;
 
             $total_pages = ceil( $count / $default_posts_per_page );
 
             for( $page = 1; $page <= $total_pages; $page++ ) {
                 $urls_to_include[] =
-                    "/{$taxonomy}/{$pagination_base}/{$page}";
+                    "/{$plural_form}/{$pagination_base}/{$page}";
             }
 
         }

--- a/readme.txt
+++ b/readme.txt
@@ -53,7 +53,7 @@ Not compatible with WooCommerce or membership sites, but solutions like [Snipcar
  - Government agencies who have strict security requirements, but have users who prefer to use WordPress
  * Thos who want to use it to archive an old WordPress website, keeping the content online, but not worrying about keeping WP up to date
 
-This plugin produces a static HTML version of your wordpress install, incredibly useful for anyone who would like the publishing power of wordpress but whose webhost doesn't allow dynamic PHP driven sites - such as GitHub Pages. You can run your development site on a different domain or offline, and the plugin will change all relevant URLs when you publish your site. It's a simple but powerful plugin, and after hitting the publish button, the plugin will output a ZIP file of your entire site, ready to upload straight to it's new home. 
+This plugin produces a static HTML version of your wordpress install, incredibly useful for anyone who would like the publishing power of wordpress but whose webhost doesn't allow dynamic PHP driven sites - such as GitHub Pages. You can run your development site on a different domain or offline, and the plugin will change all relevant URLs when you publish your site. It's a simple but powerful plugin, and after hitting the publish button, the plugin will output a ZIP file of your entire site, ready to upload straight to it's new home.
 
 
 = Getting started =
@@ -118,7 +118,7 @@ Anywhere that allows HTML files to be uploaded, ie:
 
 = My export failed - how do I proceed? =
 
-Everyone's WordPress hosting environment and configuration is unique, with different plugins, themes, PHP versions, to name a few. Whilst the plugin does its best to support all environments, sometimes you'll encounter a new issue. Sometimes we can adjust the settings in the plugin to overcome an issue, other times, it will require a bugfix and a new release of the plugin (usually a quick process). 
+Everyone's WordPress hosting environment and configuration is unique, with different plugins, themes, PHP versions, to name a few. Whilst the plugin does its best to support all environments, sometimes you'll encounter a new issue. Sometimes we can adjust the settings in the plugin to overcome an issue, other times, it will require a bugfix and a new release of the plugin (usually a quick process).
 
 When you have an issue, send the contents of your "Export Log" on the plugin screen to the developer, at [help@wp2static.com](mailto:help@wp2static.com). He'll usually respond within 12 hrs, often sooner.
 
@@ -137,6 +137,7 @@ When you have an issue, send the contents of your "Export Log" on the plugin scr
 = 6.5 =
 
  * Enhancement: pagination URLs for all post types now included in initial crawl
+ * Enhancement: pagination URLs for taxonomies, comments now included in initial crawl
  * Bugfix: posts and page URLs weren't all being detected
 
 = 6.4 =
@@ -234,7 +235,7 @@ When you have an issue, send the contents of your "Export Log" on the plugin scr
 = 5.7 =
 
  * Bugfix: Allow for WPMU/network site activation
- * Bugfix: Include gallery files for NextGEN Gallery 
+ * Bugfix: Include gallery files for NextGEN Gallery
 
 = 5.6 =
 
@@ -261,7 +262,7 @@ When you have an issue, send the contents of your "Export Log" on the plugin scr
 
  * Improvement: more deployment options included (Netlify, GitHub Pages)
  * Bugfix: certain cases where inline style images are written with incorrect filenames
- * Bugfix: fix for cron-scheduled exports failing 
+ * Bugfix: fix for cron-scheduled exports failing
  * Bugfix: offline copy not rewriting home URLs
 
 = 5.3 =
@@ -314,7 +315,7 @@ When you have an issue, send the contents of your "Export Log" on the plugin scr
 = 3.1 =
 
  * Bugfix: fix certain CloudFront exceptions not being caught/logged
- * Bugfix: previous exports being included in deployments in some cases 
+ * Bugfix: previous exports being included in deployments in some cases
  * Bugfix: issue preventing Dropbox deployments from working
  * Bugfix: enable S3 deploys to all regions
  * Bugfix: allow crawling local/self-cert SSL sites
@@ -383,12 +384,12 @@ When you have an issue, send the contents of your "Export Log" on the plugin scr
 
 = 2.4 =
 
- * Feature: Export to BunnyCDN - a very cheap and quick static site hosting option 
+ * Feature: Export to BunnyCDN - a very cheap and quick static site hosting option
  * Bugfix: Extracts relative URLs like fonts, background images, etc linked from your theme's CSS files
 
 = 2.3 =
 
- * Feature: Scheduled exports via WP Crontrol 
+ * Feature: Scheduled exports via WP Crontrol
  * Bugfix: FTP export now works on shared/limited hosting
  * Bugfix: Extracts all URLs when crawling your website's HTML files
  * Bugfix: Subsequent exports correctly show realtime progress in log
@@ -414,7 +415,7 @@ Critical bug fixes and a shiny new feature!
  * Bugfix: Amazon S3 publishing fixed after bug introduced in 1.9
  * Feature: 1-click publishing to a GitHub Pages static site
 
-Thanks to a user donation for funding the development work to get GitHub Pages exporting added as a new feature. I was also able to merge some recently contributed code from @patrickdk77, fixing the recent issues with AWS S3 and CloudFront. Finally, I couldn't make a new release without fixing the Dropbox export functionality - unbeknowst to me, they had killed version 1 of their API in September, breaking the functionality in this plugin, along with many other apps. 
+Thanks to a user donation for funding the development work to get GitHub Pages exporting added as a new feature. I was also able to merge some recently contributed code from @patrickdk77, fixing the recent issues with AWS S3 and CloudFront. Finally, I couldn't make a new release without fixing the Dropbox export functionality - unbeknowst to me, they had killed version 1 of their API in September, breaking the functionality in this plugin, along with many other apps.
 
 = 1.9 =
 
@@ -426,7 +427,7 @@ Though this is no longer an officially supported PHP version, many of this plugi
 
  * Bugfix: improved URL rewriting
 
-Plugin now ensures that formatted versions of your site's URL, ie //mydomain.com or http:\/\/mydomain.com\/ or the https/http equivalent are detected and rewritten to your target Base URL. The rewriting should now also work within CSS and JavaScript files. 
+Plugin now ensures that formatted versions of your site's URL, ie //mydomain.com or http:\/\/mydomain.com\/ or the https/http equivalent are detected and rewritten to your target Base URL. The rewriting should now also work within CSS and JavaScript files.
 
 = 1.7 =
 
@@ -477,30 +478,30 @@ Plugin now ensures that formatted versions of your site's URL, ie //mydomain.com
 = 1.1.1 =
 
 Added Features
- 
+
 * Updated author URL
 
 Removed Features
- 
+
 * Premium options for One-Click publishing to provided hosting and domain
 
 = 1.1.0 =
 
 Added Features
- 
+
 * Premium options for One-Click publishing to provided hosting and domain
 
 = 1.0.9 =
 
 Added Features
- 
-* Japanese localization added (ja_UTF) 
+
+* Japanese localization added (ja_UTF)
 
 = 1.0.8 =
 
 Added Features
- 
-* long-awaited FTP transfer option integrated with basic functionality 
+
+* long-awaited FTP transfer option integrated with basic functionality
 * option to save generated static HTML files on server
 
 = 1.0.7 =
@@ -508,23 +509,23 @@ Added Features
 Fixed bug introduced with previous version. Applied following modifications contributed by Brian Coca (https://github.com/bcoca):
 
 Added Features
- 
+
 * zip is now written atomically (write tmp file first, then rename to zip) which now allows polling scripts to only deal with completed zip file.
 * username and blog id are now part of the file name. For auditing and handling 
 multi site exports.
 
 Bug fixes
- 
+
 * . and .. special directory entries are now ignored
-* dirname is checked before access avoiding uninitialized warning 
+* dirname is checked before access avoiding uninitialized warning
 
 = 1.0.6 =
 
-Added shortcut to Settings page with Plugin Action Links   
+Added shortcut to Settings page with Plugin Action Links
 
 = 1.0.5 =
 
-Added link to relevant Settings page when permalinks structure is not set.  
+Added link to relevant Settings page when permalinks structure is not set.
 
 = 1.0.4 =
 
@@ -535,7 +536,7 @@ Added a timeout value to URL request which was breaking for slow sites
 Altered main codebase to fix recursion bug and endless loop. Essential upgrade. 
 
 = 1.0.2 =
- 
+
 Initial release to Wordpress community
 
 == Upgrade Notice ==
@@ -543,6 +544,7 @@ Initial release to Wordpress community
 = 6.5 =
 
  * Enhancement: pagination URLs for all post types now included in initial crawl
+ * Enhancement: pagination URLs for taxonomies, comments now included in initial crawl
  * Bugfix: posts and page URLs weren't all being detected
 
 = 6.4 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: security, performance, static
 Requires at least: 3.2
 Tested up to: 5.0.2
 Requires PHP: 5.6
-Stable tag: 6.4
+Stable tag: 6.5
 
 Security & Performance via static website publishing. One plugin to solve WordPress's biggest problems.
 
@@ -133,6 +133,10 @@ When you have an issue, send the contents of your "Export Log" on the plugin scr
 7. Ways to support the plugin
 
 == Changelog ==
+
+= 6.5 =
+
+ * Bugfix: 
 
 = 6.4 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -136,7 +136,8 @@ When you have an issue, send the contents of your "Export Log" on the plugin scr
 
 = 6.5 =
 
- * Bugfix: 
+ * Enhancement: pagination URLs for all post types now included in initial crawl
+ * Bugfix: posts and page URLs weren't all being detected
 
 = 6.4 =
 
@@ -538,6 +539,11 @@ Altered main codebase to fix recursion bug and endless loop. Essential upgrade.
 Initial release to Wordpress community
 
 == Upgrade Notice ==
+
+= 6.5 =
+
+ * Enhancement: pagination URLs for all post types now included in initial crawl
+ * Bugfix: posts and page URLs weren't all being detected
 
 = 6.4 =
 

--- a/wp2static.php
+++ b/wp2static.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP2Static
  * Plugin URI:  https://wp2static.com
  * Description: Security & Performance via static website publishing. One plugin to solve WordPress's biggest problems.
- * Version:     6.5-dev
+ * Version:     6.5
  * Author:      Leon Stafford
  * Author URI:  https://leonstafford.github.io
  * Text Domain: static-html-output-plugin

--- a/wp2static.php
+++ b/wp2static.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP2Static
  * Plugin URI:  https://wp2static.com
  * Description: Security & Performance via static website publishing. One plugin to solve WordPress's biggest problems.
- * Version:     6.4
+ * Version:     6.5-dev
  * Author:      Leon Stafford
  * Author URI:  https://leonstafford.github.io
  * Text Domain: static-html-output-plugin


### PR DESCRIPTION
== Changelog ==

= 6.5 =

 * Enhancement: pagination URLs for all post types now included in initial crawl
 * Enhancement: pagination URLs for taxonomies, comments now included in initial crawl
 * Bugfix: posts and page URLs weren't all being detected
