### PR TITLE
Hotfix 281 homepage 404 custom posts links

### DIFF
--- a/languages/static-html-output-plugin.pot
+++ b/languages/static-html-output-plugin.pot
@@ -1,7 +1,7 @@
 # WP Static HTML Output
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Static Site Generator 6.5\n"
+"Project-Id-Version: WP Static Site Generator 6.5.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wp-static-html-output\n"
 "POT-Creation-Date: 2018-04-25 14:34:12+00:00\n"

--- a/library/StaticHtmlOutput.php
+++ b/library/StaticHtmlOutput.php
@@ -1,7 +1,7 @@
 <?php
 
 class StaticHtmlOutput_Controller {
-    const VERSION = '6.5';
+    const VERSION = '6.5.1';
     const OPTIONS_KEY = 'wp2static-options';
     const HOOK = 'wp2static';
 

--- a/library/StaticHtmlOutput/FilesHelper.php
+++ b/library/StaticHtmlOutput/FilesHelper.php
@@ -462,9 +462,7 @@ class StaticHtmlOutput_FilesHelper {
 
         foreach ( $posts as $post ) {
             // capture all post types
-            if ( $post->post_type !== 'wpcf7_contact_form' ) {
-                $unique_post_types[] = $post->post_type;
-            }
+            $unique_post_types[] = $post->post_type;
 
             switch ( $post->post_type ) {
                 case 'page':
@@ -479,6 +477,10 @@ class StaticHtmlOutput_FilesHelper {
                 default:
                     $permalink = get_post_permalink( $post->ID );
                     break;
+            }
+
+            if ( strpos( $permalink, '?post_type' ) !== false ) {
+                continue;
             }
 
             $post_urls[] = $permalink;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: security, performance, static
 Requires at least: 3.2
 Tested up to: 5.0.2
 Requires PHP: 5.6
-Stable tag: 6.5
+Stable tag: 6.5.1
 
 Security & Performance via static website publishing. One plugin to solve WordPress's biggest problems.
 
@@ -133,6 +133,10 @@ When you have an issue, send the contents of your "Export Log" on the plugin scr
 7. Ways to support the plugin
 
 == Changelog ==
+
+= 6.5.1 =
+
+ * Bugfix: fixes exports where homepage is 404
 
 = 6.5 =
 
@@ -540,6 +544,10 @@ Altered main codebase to fix recursion bug and endless loop. Essential upgrade.
 Initial release to Wordpress community
 
 == Upgrade Notice ==
+
+= 6.5.1 =
+
+ * Bugfix: fixes exports where homepage is 404
 
 = 6.5 =
 

--- a/wp2static.php
+++ b/wp2static.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP2Static
  * Plugin URI:  https://wp2static.com
  * Description: Security & Performance via static website publishing. One plugin to solve WordPress's biggest problems.
- * Version:     6.5
+ * Version:     6.5.1
  * Author:      Leon Stafford
  * Author URI:  https://leonstafford.github.io
  * Text Domain: static-html-output-plugin


### PR DESCRIPTION
Fixes issue where exported homepage is a 404 page: 

referenced:

 - https://github.com/leonstafford/wp2static/issues/281
 - https://forum.wp2static.com/-64#post-9

