### PR TITLE
Hotfix urls with spaces initial crawl list

### DIFF
--- a/languages/static-html-output-plugin.pot
+++ b/languages/static-html-output-plugin.pot
@@ -1,7 +1,7 @@
 # WP Static HTML Output
 msgid ""
 msgstr ""
-"Project-Id-Version: WP Static Site Generator 6.5.1\n"
+"Project-Id-Version: WP Static Site Generator 6.5.2\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/wp-static-html-output\n"
 "POT-Creation-Date: 2018-04-25 14:34:12+00:00\n"

--- a/library/StaticHtmlOutput.php
+++ b/library/StaticHtmlOutput.php
@@ -1,7 +1,7 @@
 <?php
 
 class StaticHtmlOutput_Controller {
-    const VERSION = '6.5.1';
+    const VERSION = '6.5.2';
     const OPTIONS_KEY = 'wp2static-options';
     const HOOK = 'wp2static';
 

--- a/library/StaticHtmlOutput/FilesHelper.php
+++ b/library/StaticHtmlOutput/FilesHelper.php
@@ -576,7 +576,19 @@ class StaticHtmlOutput_FilesHelper {
             $comment_pagination_urls
         );
 
-        return array_unique( $post_urls );
+        $unique_urls = array_unique( $post_urls );
+
+        $search_text = ' ';
+
+        $all_urls = array_filter(
+            $unique_urls,
+            function( $a ) use ( $search_text ) {
+                return ( strpos( $unique_urls, $search_text ) === false );
+            }
+        );
+
+
+        return $all_urls;
     }
 
     public static function getPaginationURLsForPosts( $post_types ) {

--- a/library/StaticHtmlOutput/FilesHelper.php
+++ b/library/StaticHtmlOutput/FilesHelper.php
@@ -587,7 +587,6 @@ class StaticHtmlOutput_FilesHelper {
             }
         );
 
-
         return $all_urls;
     }
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: security, performance, static
 Requires at least: 3.2
 Tested up to: 5.0.2
 Requires PHP: 5.6
-Stable tag: 6.5.1
+Stable tag: 6.5.2
 
 Security & Performance via static website publishing. One plugin to solve WordPress's biggest problems.
 
@@ -133,6 +133,10 @@ When you have an issue, send the contents of your "Export Log" on the plugin scr
 7. Ways to support the plugin
 
 == Changelog ==
+
+= 6.5.2 =
+
+ * Bugfix: filter URLs with spaces from initial crawl list
 
 = 6.5.1 =
 
@@ -544,6 +548,10 @@ Altered main codebase to fix recursion bug and endless loop. Essential upgrade.
 Initial release to Wordpress community
 
 == Upgrade Notice ==
+
+= 6.5.2 =
+
+ * Bugfix: filter URLs with spaces from initial crawl list
 
 = 6.5.1 =
 

--- a/wp2static.php
+++ b/wp2static.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP2Static
  * Plugin URI:  https://wp2static.com
  * Description: Security & Performance via static website publishing. One plugin to solve WordPress's biggest problems.
- * Version:     6.5.1
+ * Version:     6.5.2
  * Author:      Leon Stafford
  * Author URI:  https://leonstafford.github.io
  * Text Domain: static-html-output-plugin


### PR DESCRIPTION
Fixes issue with certain WP plugins/themes leading to plugin detecting malformed URLs containing spaces for initial crawl list. This filters out URLs with spaces