### PR TITLE
Avoid replacing "//" in URL scheme.

### DIFF
--- a/plugin/WP2Static/FilesHelper.php
+++ b/plugin/WP2Static/FilesHelper.php
@@ -587,13 +587,7 @@ class WP2Static_FilesHelper {
 
         $unique_urls = array_unique( $post_urls );
 
-        $urls = str_replace(
-            '//',
-            '/',
-            $unique_urls
-        );
-
-        return $urls;
+        return $unique_urls;
     }
 
     public static function getPaginationURLsForPosts( $post_types ) {
@@ -644,11 +638,12 @@ class WP2Static_FilesHelper {
         $default_posts_per_page = get_option( 'posts_per_page' );
 
         foreach ( $categories as $term => $total_posts ) {
+            $term_url = rtrim( $term, '/' );
             $total_pages = ceil( $total_posts / $default_posts_per_page );
 
             for ( $page = 1; $page <= $total_pages; $page++ ) {
                 $urls_to_include[] =
-                    "{$term}/{$pagination_base}/{$page}";
+                    "{$term_url}/{$pagination_base}/{$page}";
             }
         }
 


### PR DESCRIPTION
The change at https://github.com/leonstafford/wp2static/commit/3e711cf892c905c5dfd0b385844426320d4995b4   (issue #292) may also replace doubleshashes in URL scheme,  `http://` to `http:/`, and then some URLs in the initial crawl list are invalid.

I thought URLs with "//" may generated at `#getPaginationURLsForCategories` so fix it, and remove `str_replace` at last of `#getAllWPPostURLs`.