### PR TITLE
Fix two phpstan errors

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -11,10 +11,16 @@ class Controller {
     const OPTIONS_KEY = 'wp2static-options';
     const HOOK = 'wp2static';
 
+    /**
+     * @var \WP2Static\Controller
+     */
     protected static $instance = null;
 
     protected function __construct() {}
 
+    /**
+     * @return \WP2Static\Controller
+     */
     public static function getInstance() {
         if ( null === self::$instance ) {
             self::$instance = new self();


### PR DESCRIPTION
Actually all classes, properties and methods should have PHPDoc blocks.