### PR TITLE
Stop discovering urls during crawl

### DIFF
--- a/src/CLI.php
+++ b/src/CLI.php
@@ -105,7 +105,6 @@ class CLI {
         $site_crawler = new SiteCrawler();
 
         $site_crawler->crawl_site();
-        $site_crawler->crawl_discovered_links();
         $plugin->post_process_archive_dir();
 
         $end_time = microtime();

--- a/src/CSSProcessor.php
+++ b/src/CSSProcessor.php
@@ -35,10 +35,6 @@ class CSSProcessor extends Base {
 
         $this->page_url = new \Net_URL2( $page_url );
 
-        $this->detectIfURLsShouldBeHarvested();
-
-        $this->discovered_urls = array();
-
         foreach ( $this->css_doc->getAllValues() as $node_value ) {
             if ( $node_value instanceof \Sabberworm\CSS\Value\URL ) {
                 $original_link = $node_value->getURL();
@@ -51,8 +47,6 @@ class CSSProcessor extends Base {
                 if ( $inline_img !== false ) {
                     continue;
                 }
-
-                $this->addDiscoveredURL( $original_link );
 
                 if ( $this->isInternalLink( $original_link ) ) {
                     if ( ! isset( $this->settings['rewrite_rules'] ) ) {
@@ -146,91 +140,6 @@ class CSSProcessor extends Base {
         );
 
         $this->raw_css = $rewritten_source;
-    }
-
-    public function detectIfURLsShouldBeHarvested() {
-        if ( defined( 'WP_CLI' ) ) {
-            if ( defined( 'CRAWLING_DISCOVERED' ) ) {
-                return;
-            } else {
-                $this->harvest_new_urls = true;
-            }
-        } else {
-            // @codingStandardsIgnoreStart
-            $this->harvest_new_urls = (
-                 $_POST['ajax_action'] === 'crawl_site'
-            );
-            // @codingStandardsIgnoreEnd
-        }
-    }
-
-    public function addDiscoveredURL( $url ) {
-        if ( ! $url ) {
-            return;
-        }
-
-        // trim any query strings or anchors
-        $url = strtok( $url, '#' );
-
-        if ( ! $url ) {
-            return;
-        }
-
-        $url = strtok( $url, '?' );
-
-        if ( ! $url ) {
-            return;
-        }
-
-        if ( trim( $url ) === '' ) {
-            return;
-        }
-
-        if ( isset( $this->harvest_new_urls ) ) {
-            if ( ! $this->isValidURL( $url ) ) {
-                return;
-            }
-
-            if ( $this->isInternalLink( $url ) ) {
-                $discovered_url_without_site_url =
-                    str_replace(
-                        rtrim( $this->placeholder_url, '/' ),
-                        '',
-                        $url
-                    );
-
-                $this->discovered_urls[] = $discovered_url_without_site_url;
-            }
-        }
-    }
-
-    public function writeDiscoveredURLs() {
-        // @codingStandardsIgnoreStart
-        if ( isset( $_POST['ajax_action'] ) &&
-            $_POST['ajax_action'] === 'crawl_again' ) {
-            return;
-        }
-        // @codingStandardsIgnoreEnd
-
-        if ( defined( 'WP_CLI' ) ) {
-            if ( defined( 'CRAWLING_DISCOVERED' ) ) {
-                return;
-            }
-        }
-
-        file_put_contents(
-            $this->settings['wp_uploads_path'] .
-                '/wp2static-working-files/DISCOVERED-URLS.txt',
-            PHP_EOL .
-                implode( PHP_EOL, array_unique( $this->discovered_urls ) ),
-            FILE_APPEND | LOCK_EX
-        );
-
-        chmod(
-            $this->settings['wp_uploads_path'] .
-                '/wp2static-working-files/DISCOVERED-URLS.txt',
-            0664
-        );
     }
 
     public function isValidURL( $url ) {

--- a/src/CSSProcessor.php
+++ b/src/CSSProcessor.php
@@ -104,8 +104,6 @@ class CSSProcessor extends Base {
             }
         }
 
-        $this->writeDiscoveredURLs();
-
         return true;
     }
 

--- a/src/Exporter.php
+++ b/src/Exporter.php
@@ -19,8 +19,6 @@ class Exporter extends Base {
     public function pre_export_cleanup() {
         $files_to_clean = array(
             '2ND-CRAWL-LIST.txt',
-            'DISCOVERED-URLS-LOG.txt',
-            'DISCOVERED-URLS.txt',
             'FILES-TO-DEPLOY.txt',
             'EXPORT-LOG.txt',
             'FINAL-2ND-CRAWL-LIST.txt',
@@ -44,7 +42,6 @@ class Exporter extends Base {
     public function cleanup_working_files() {
         $files_to_clean = array(
             '2ND-CRAWL-LIST.txt',
-            'DISCOVERED-URLS.txt',
             'FILES-TO-DEPLOY.txt',
             'FINAL-2ND-CRAWL-LIST.txt',
             'FINAL-CRAWL-LIST.txt',

--- a/src/HTMLProcessor.php
+++ b/src/HTMLProcessor.php
@@ -125,7 +125,6 @@ class HTMLProcessor extends Base {
 
         $this->dealWithBaseHREFElement();
         $this->stripHTMLComments();
-        $this->writeDiscoveredURLs();
 
         return true;
     }

--- a/src/SiteCrawler.php
+++ b/src/SiteCrawler.php
@@ -109,19 +109,6 @@ class SiteCrawler extends Base {
         $total_urls_path = $this->settings['wp_uploads_path'] .
             '/wp2static-working-files/INITIAL-CRAWL-TOTAL.txt';
 
-        // TODO: avoid mutation
-        // @codingStandardsIgnoreStart
-        if (
-            defined( 'CRAWLING_DISCOVERED' ) ||
-            ( isset( $_POST['ajax_action'] ) &&
-                $_POST['ajax_action'] == 'crawl_again'
-            )
-        ) {
-            $total_urls_path = $this->settings['wp_uploads_path'] .
-            '/wp2static-working-files/DISCOVERED-URLS-TOTAL.txt';
-        }
-        // @codingStandardsIgnoreEnd
-
         $exclusions = array( 'wp-json' );
 
         if ( isset( $this->settings['excludeURLs'] ) ) {

--- a/views/options-page-js.phtml
+++ b/views/options-page-js.phtml
@@ -42,7 +42,6 @@ var pollingIntervalID = '';
 var timerIntervalID = '';
 var status_descriptions = {
     'crawl_site' : 'Crawling initial file list',
-    'crawl_again' : 'Crawling discovered URLs',
     'post_process_archive_dir' : 'Processing the crawled files',
     'post_export_teardown' : 'Cleaning up after processing'
 };
@@ -244,7 +243,6 @@ jQuery(document).ready(function($){
   function startExportSuccessCallback( serverResponse ) {
       var initial_steps = [
         'crawl_site',
-        'crawl_again',
         'post_process_archive_dir'
       ];
 
@@ -407,7 +405,7 @@ jQuery(document).ready(function($){
       SUCCESS - action is complete
       > 0 - action is in progress inremental task
       ERROR
-        
+
       if an action is successful, and there are other actions queued up,
       it will call the function again with the remaining arguments/actions
 
@@ -577,8 +575,7 @@ jQuery(document).ready(function($){
   function loadLogFile() {
     // display loading icon
     $('#log_load_progress').show();
-        
-    // set textarea to disabled
+
     $("#export_log_textarea" ).attr('disabled', true);
 
     // set textarea content to 'Loading log file...'


### PR DESCRIPTION
Reducing complexity and refocusing on the URL detection and then add-on solutions  for plugins/themes with funky URLs unable to be detected from WP/filesystem 

cc @fransallen 