### PR TITLE
Added WP-CLI command options unset <option name>.

### DIFF
--- a/plugin/WP2Static/Options.php
+++ b/plugin/WP2Static/Options.php
@@ -156,6 +156,10 @@ class WP2Static_Options {
     public function __set( $name, $value ) {
         $this->wp2static_options[ $name ] = $value;
 
+        if ( empty( $value ) ) {
+            unset( $this->wp2static_options[ $name ] );
+        }
+
         // NOTE: this is required, not certain why, investigate
         // and make more intuitive
         return $this;

--- a/plugin/wp2static-wp-cli-commands.php
+++ b/plugin/wp2static-wp-cli-commands.php
@@ -234,6 +234,25 @@ function wp2static_options( $args, $assoc_args ) {
         }
     }
 
+    if ( $action === 'unset' ) {
+        if ( empty( $option_name ) ) {
+            WP_CLI::error( 'Missing required argument: <option-name>' );
+        }
+
+        if ( ! $plugin->options->optionExists( $option_name ) ) {
+            WP_CLI::error( 'Invalid option name' );
+        }
+
+        $plugin->options->setOption( $option_name, '' );
+        $plugin->options->save();
+
+        $result = $plugin->options->getOption( $option_name );
+
+        if ( ! empty( $result ) ) {
+            WP_CLI::error( 'Option not able to be updated' );
+        }
+    }
+
     if ( $action === 'list' ) {
         if ( isset( $assoc_args['reveal-sensitive-values'] ) ) {
             $reveal_sensitive_values = true;


### PR DESCRIPTION
There was a set and get option, but there was no way to "unset" an option. You can't set an option to 0 or false because that would cause a `Missing required argument: <value>` to appear. I added the code so now you can use unset. For example: `wp wp2static options unset targetFolder`.