### PR TITLE
#401 - url embeded in css rules not being rewritten

### DIFF
--- a/plugin/WP2Static/CSSProcessor.php
+++ b/plugin/WP2Static/CSSProcessor.php
@@ -61,6 +61,7 @@ class CSSProcessor extends WP2Static {
         $this->placeholder_url = $protocol . 'PLACEHOLDER.wpsho/';
 
         $this->raw_css = $css_document;
+
         // initial rewrite of all site URLs to placeholder URLs
         $this->rewriteSiteURLsToPlaceholder();
 
@@ -89,8 +90,13 @@ class CSSProcessor extends WP2Static {
 
                 $this->addDiscoveredURL( $original_link );
 
-                if ( $this->isInternalLink( $original_link ) ) {
-                    if ( ! isset( $this->settings['rewrite_rules'] ) ) {
+                // #401 - url embeded in css rules not being rewritten
+                //        Check for the presence of PLACEHOLDER.wpsho within the URL
+
+                if ( $this->isInternalLink( $original_link ) || strpos( $original_link, $this->placeholder_url ) !== false ) 
+                {
+                    if ( ! isset( $this->settings['rewrite_rules'] ) ) 
+                    {
                         $this->settings['rewrite_rules'] = '';
                     }
 
@@ -136,7 +142,7 @@ class CSSProcessor extends WP2Static {
                 }
             }
         }
-
+        
         $this->writeDiscoveredURLs();
 
         return true;

--- a/wp2static.php
+++ b/wp2static.php
@@ -3,7 +3,11 @@
  * Plugin Name: WP2Static
  * Plugin URI:  https://wp2static.com
  * Description: Security & Performance via static website publishing. One plugin to solve WordPress's biggest problems.
+<<<<<<< HEAD
  * Version:     6.6.5
+=======
+ * Version:     6.6.8-dev-MED
+>>>>>>> 97671a0... #401 - url embeded in css rules not being rewritten
  * Author:      Leon Stafford
  * Author URI:  https://leonstafford.github.io
  * Text Domain: static-html-output-plugin


### PR DESCRIPTION
If the url is embeded in a css rule it is not being rewritten.  An example of this is when using Optimole image caching.  background-image urls are rewritten by the Optimole plugin as follows.

`background-image: url('http://domain.com/background_image.jpg' );`

becomes

`background-image: url('https://xxxxxxxxxi.optimole.com/w:auto/h:auto/q:auto/http://domain.com/background_image.jpg' );`

When the CSS is process all occurences of 'domain.com' are replaced with 'PLACEHOLDER.wpsho'.  However only urls that start with PLACEHOLDER.wpsho are rewritten leaving a broken css rule like this

`background-image: url('https://xxxxxxxxxi.optimole.com/w:auto/h:auto/q:auto/http://PLACEHOLDER.wpsho/background_image.jpg' );`

