### PR TITLE
Preserve html entities

### DIFF
--- a/plugin/WP2Static/HTMLProcessor.php
+++ b/plugin/WP2Static/HTMLProcessor.php
@@ -692,6 +692,18 @@ class HTMLProcessor extends WP2Static {
             $processed_html
         );
 
+        // Allow themes to modify entities to preserve
+        $html_entities_to_preserve = apply_filters( 'wp2static_html_entities_to_preserve', array( '&lt;', '&gt;' ) );
+
+        // Strip entities down to just the "name"
+        $cleaned_entities_to_preserve = preg_replace('/^&(.*?);$/', '\1', $html_entities_to_preserve);
+
+        // Build up the regex from the entity "names"
+        $preserve_entities_rx = sprintf( '/&(%s);/', implode('|', $cleaned_entities_to_preserve) );
+
+        // Replace entities with placeholders to preserve them
+        $processed_html = preg_replace($preserve_entities_rx, '{{wp2static-entity-placeholder:\1}}', $processed_html);
+
         $processed_html = html_entity_decode(
             $processed_html,
             ENT_QUOTES,
@@ -704,6 +716,9 @@ class HTMLProcessor extends WP2Static {
             ENT_QUOTES,
             'UTF-8'
         );
+
+        // Restore actual entities from placeholders
+        $processed_html = preg_replace('/{{wp2static-entity-placeholder:(.*?)}}/', '&\1;', $processed_html);
 
         return $processed_html;
     }

--- a/tests/HTMLProcessor/entityPreservationTest.php
+++ b/tests/HTMLProcessor/entityPreservationTest.php
@@ -1,0 +1,77 @@
+<?php
+
+chdir( dirname(__FILE__) . '/../../plugin' );
+
+$plugin_dir = getcwd();
+
+require_once $plugin_dir . '/WP2Static/WP2Static.php';
+require_once $plugin_dir . '/WP2Static/HTMLProcessor.php';
+require_once $plugin_dir . '/URL2/URL2.php';
+
+use PHPUnit\Framework\TestCase;
+
+// Create basic helper for filters so code is testable
+function apply_filters($name, $default) {
+  return $default;
+}
+
+final class HTMLProcessorEntityPreservationTest extends TestCase {
+
+    /**
+     * @dataProvider entityProvider
+     */
+    public function testEntityPreservation(
+        $test_HTML_content,
+        $exp_result
+        ) {
+
+        $mockProcessor = $this->getMockBuilder( 'HTMLProcessor' )
+            ->setMethods(
+                [
+                    'loadSettings',
+                    'rewriteSiteURLsToPlaceholder',
+                    'detectIfURLsShouldBeHarvested',
+                    'writeDiscoveredURLs',
+                ]
+            )
+            ->getMock();
+
+        $page_URL = new Net_URL2(
+            'http://mywpsite.com/category/photos/my-gallery/'
+        );
+
+        $mockProcessor->method( 'loadSettings' )->willReturn( null );
+
+        $mockProcessor->method( 'rewriteSiteURLsToPlaceholder' )->willReturn(
+            $test_HTML_content
+        );
+
+        $mockProcessor->method( 'detectIfURLsShouldBeHarvested' )->willReturn( null );
+        $mockProcessor->method( 'writeDiscoveredURLs' )->willReturn( null );
+
+        $mockProcessor->settings = array(
+            'baseUrl' => 'http://baseurldomainfromsettings.com/',
+        );
+
+        $mockProcessor->processHTML( $test_HTML_content, $page_URL );
+
+        $this->assertEquals(
+            $exp_result,
+            $mockProcessor->getHTML()
+        );
+
+    }
+
+    public function entityProvider() {
+        return [
+           'HTML entities to be preserved in source' =>  [
+                '<!DOCTYPE html><html lang="en-US"><head></head><body><p><code>/DescriptorPrefix/&lt;tableid&gt;</code>. Each row in the table is stored at key <code>/&lt;tableid&gt;/&lt;primarykey&gt;</code>.</p></body></html>',
+                '<!DOCTYPE html>
+<html lang="en-US"><head></head><body><p><code>/DescriptorPrefix/&lt;tableid&gt;</code>. Each row in the table is stored at key <code>/&lt;tableid&gt;/&lt;primarykey&gt;</code>.</p></body></html>
+',
+            ],
+        ];
+    }
+}
+
+


### PR DESCRIPTION
This fixes #437 and was based on https://github.com/WP2Static/wp2static/tree/6.6.5 because I'd like to get it into the 6.x codebase

The same approach should work in the 7.x codebase