### PR TITLE
Fix attempt to get ID column from crawl_cache table

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,7 @@ Not compatible with WooCommerce or membership sites, but solutions like [Snipcar
  - Operations people at large corporations don't often like dealing with WordPress, this allows them to close the security holes and have more control over the hosting
  - Budget conscious people like free hosting (who doesn't?!?)
  - Government agencies who have strict security requirements, but have users who prefer to use WordPress
- * Thos who want to use it to archive an old WordPress website, keeping the content online, but not worrying about keeping WP up to date
+ - Those who want to use it to archive an old WordPress website, keeping the content online, but not worrying about keeping WP up to date
 
 This plugin produces a static HTML version of your wordpress install, incredibly useful for anyone who would like the publishing power of wordpress but whose webhost doesn't allow dynamic PHP driven sites - such as GitHub Pages. You can run your development site on a different domain or offline, and the plugin will change all relevant URLs when you publish your site. It's a simple but powerful plugin, and after hitting the publish button, the plugin will output a ZIP file of your entire site, ready to upload straight to it's new home.
 

--- a/src/CrawlCache.php
+++ b/src/CrawlCache.php
@@ -58,8 +58,6 @@ class CrawlCache {
     public static function rmUrl( string $url ) : void {
         global $wpdb;
 
-        $hashed_url = md5( $url );
-
         $table_name = $wpdb->prefix . 'wp2static_crawl_cache';
 
         $wpdb->delete(

--- a/src/CrawlCache.php
+++ b/src/CrawlCache.php
@@ -12,6 +12,7 @@ class CrawlCache {
         $charset_collate = $wpdb->get_charset_collate();
 
         $sql = "CREATE TABLE $table_name (
+            id INT UNSIGNED NOT NULL AUTO_INCREMENT,
             hashed_url CHAR(32) NOT NULL,
             time datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
             PRIMARY KEY  (hashed_url)

--- a/src/CrawlCache.php
+++ b/src/CrawlCache.php
@@ -12,7 +12,6 @@ class CrawlCache {
         $charset_collate = $wpdb->get_charset_collate();
 
         $sql = "CREATE TABLE $table_name (
-            id INT UNSIGNED NOT NULL AUTO_INCREMENT,
             hashed_url CHAR(32) NOT NULL,
             time datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
             PRIMARY KEY  (hashed_url)
@@ -37,7 +36,7 @@ class CrawlCache {
     }
 
     // TODO: enable date filter as option/alternate method
-    public static function getUrl( string $url ) : int {
+    public static function getUrl( string $url ) : string {
         global $wpdb;
 
         $hashed_url = md5( $url );
@@ -45,14 +44,14 @@ class CrawlCache {
         $table_name = $wpdb->prefix . 'wp2static_crawl_cache';
 
         $sql = $wpdb->prepare(
-            "SELECT id FROM $table_name WHERE" .
+            "SELECT hashed_url FROM $table_name WHERE" .
             ' hashed_url = %s LIMIT 1',
             $hashed_url
         );
 
         $id = $wpdb->get_var( $sql );
 
-        return (int) $id;
+        return (string) $id;
     }
 
     public static function rmUrl( string $url ) : void {


### PR DESCRIPTION
No method actually tries to use a numerical value from the `getUrl` method, so changing its signature to return a string should be safe.

This PR will stop error-log pollution.