### PR TITLE
Fix HTTP Basic Auth

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: security, performance, static
 Requires at least: 4.0
 Tested up to: 5.4
 Requires PHP: 7.2
-Stable tag: 7.0-alpha-003
+Stable tag: 7.0-alpha-004
 
 Static site generator functionality for WordPress.
 

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -8,7 +8,7 @@ use WP_CLI;
 use WP_Post;
 
 class Controller {
-    const WP2STATIC_VERSION = '7.0-alpha-003';
+    const WP2STATIC_VERSION = '7.0-alpha-004';
 
     /**
      * @var string

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -221,8 +221,12 @@ class CoreOptions {
 
         $option_value = $wpdb->get_var( $sql );
 
-        if ( ! is_string( $option_value ) ) {
+        if ( ! $option_value || ! is_string( $option_value ) ) {
             return '';
+        }
+
+        if ( $name === 'basicAuthPassword' ) {
+            return self::encrypt_decrypt( 'decrypt', $option_value );
         }
 
         return $option_value;

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -46,12 +46,14 @@ class Crawler {
             apply_filters( 'wp2static_curl_user_agent', 'WP2Static.com' )
         );
 
-        if ( CoreOptions::getValue( 'useBasicAuth' ) ) {
+        $auth_user = CoreOptions::getValue( 'basicAuthUser' );
+        $auth_password = CoreOptions::getValue( 'basicAuthPassword' );
+
+        if ( $auth_user || $auth_password ) {
             curl_setopt(
                 $this->ch,
                 CURLOPT_USERPWD,
-                CoreOptions::getValue( 'basicAuthUser' ) . ':' .
-                CoreOptions::getValue( 'basicAuthPassword' )
+                $auth_user . ':' . $auth_password
             );
         }
     }

--- a/wp2static.php
+++ b/wp2static.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP2Static
  * Plugin URI:  https://wp2static.com
  * Description: Static site generator functionality for WordPress.
- * Version:     7.0-alpha-003
+ * Version:     7.0-alpha-004
  * Author:      WP2Static
  * Author URI:  https://wp2static.com
  * Text Domain: static-html-output-plugin


### PR DESCRIPTION
Basic Auth doesn't work at all because
1. It depends on a useBasicAuth option, but this option does not appear in the admin, so username and password are always ignored
2. Even if you add useBasicAuth to the DB, the password is not decrypted properly and is sent raw, so authentication fails.

These commits remove the useBasicAuth option entirely and make sure that the decrypted password value is used.