### PR TITLE
Improve encryption strength

### DIFF
--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -309,19 +309,21 @@ class CoreOptions {
             'ec64SSHB{8|AA_ThIIlm:PD(Z!qga!/Dwll 4|i.?UkC§NNO}z?{Qr/q.KpH55K9';
 
         $key = hash( 'sha256', $secret_key );
-        $variate = substr( hash( 'sha256', $secret_iv ), 0, 16 );
+        $variate = substr( hash( 'sha256', $secret_iv ), 0, 32 );
+        $hex_key = hex2bin( $key );
+        $hex_iv = hex2bin( $variate );
 
         if ( $action == 'decrypt' ) {
             return (string) openssl_decrypt(
                 (string) base64_decode( $string ),
                 $encrypt_method,
-                $key,
+                $hex_key,
                 0,
-                $variate
+                $hex_iv
             );
         }
 
-        $output = openssl_encrypt( $string, $encrypt_method, $key, 0, $variate );
+        $output = openssl_encrypt( $string, $encrypt_method, $hex_key, 0, $hex_iv );
 
         return (string) base64_encode( (string) $output );
     }


### PR DESCRIPTION
The encryption uses AES256, but the implementation silently discards half of the available entropy. That is, we take a sha256 hash of $secret_key, which is 64 hex chars, but the implementation only uses the first 32 chars, which is 256 bits of memory but only 128 bits of entropy. I instead call hex2bin to decode the 64 hex chars into 32 bytes of memory. There is a similar issue with the initial variate which I also patched.

There is an explanation at https://stackoverflow.com/questions/55062897/decrypt-aes256-on-python-vs-php/55063033#55063033. The root problem here is that openssl_decrypt and openssl_encrypt silently truncate the key, discarding half of the entropy without warning.