### PR TITLE
Add a process_queue command to the WP CLI.

### DIFF
--- a/src/CLI.php
+++ b/src/CLI.php
@@ -342,6 +342,24 @@ class CLI {
         $post_processor->processStaticSite( StaticSite::getPath() );
     }
 
+
+    /**
+     * Process any jobs in the queue.
+     */
+    public function process_queue() : void {
+        $job_count = JobQueue::getWaitingJobs();
+
+        if ( $job_count === 0 ) {
+            WP_CLI::success( 'No jobs in queue' );
+        } else {
+            WP_CLI::line( ' Processing ' . $job_count . ' job' . ( $job_count > 1 ? 's' : '' ) );
+
+            Controller::wp2static_process_queue();
+
+            WP_CLI::success( 'Done processing queue' );
+        }
+    }
+
     /**
      * Crawl Queue
      *

--- a/src/JobQueue.php
+++ b/src/JobQueue.php
@@ -191,6 +191,21 @@ class JobQueue {
     }
 
     /**
+     *  Get count of waiting jobs
+     *
+     *  @return int Waiting jobs
+     */
+    public static function getWaitingJobs() : int {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wp2static_jobs';
+
+        $total_jobs = $wpdb->get_var( "SELECT COUNT(*) FROM $table_name WHERE status = 'waiting'" );
+
+        return $total_jobs;
+    }
+
+    /**
      *  Clear JobQueue via truncate or deletion
      */
     public static function truncate() : void {

--- a/views/jobs-page.php
+++ b/views/jobs-page.php
@@ -151,7 +151,7 @@
         value="10">every 10 minutes</option>
 </select>
 
-<p><i>If WP-Cron is not expected to be triggered by site visitors, you can also call `wp-cron.php` directly, run the WP-CLI command `wp wp2static process_job_queue` or call the hook `wp2static_process_queue` from within your own theme or plugin.</i></p>
+<p><i>If WP-Cron is not expected to be triggered by site visitors, you can also call `wp-cron.php` directly, run the WP-CLI command `wp wp2static process_queue` or call the hook `wp2static_process_queue` from within your own theme or plugin.</i></p>
 
     <button class="button btn-primary">Save Job Automation Settings</button>
     <?php wp_nonce_field( $view['nonce_action'] ); ?>


### PR DESCRIPTION
tl;dr cron is much more reliable than wp-cron.