### PR TITLE
fix: require composer autoload

### DIFF
--- a/wp2static.php
+++ b/wp2static.php
@@ -13,7 +13,9 @@
 
 define( 'WP2STATIC_PATH', plugin_dir_path( __FILE__ ) );
 
-require WP2STATIC_PATH . 'vendor/autoload.php';
+if ( file_exists( WP2STATIC_PATH . 'vendor/autoload.php' ) ) {
+  require_once WP2STATIC_PATH . 'vendor/autoload.php';
+}
 
 WP2Static\Controller::init( __FILE__ );
 


### PR DESCRIPTION
Require composer autoload only when we don't use the composer schema for the project.
Right now I am using composer for the whole project and when I load it via composer require wp2static/wp2static:7.0-alpha-004 I had all dependencies which I need. But my vendor dir doesn't present in the plugin folder.