### PR TITLE
Update path for Windows usage in WP2Static 6.6.7 - Github Pages issue

### DIFF
--- a/src/SiteInfo.php
+++ b/src/SiteInfo.php
@@ -96,7 +96,7 @@ class SiteInfo {
         }
 
         // Standardise all paths to use / (Windows support)
-        $path = str_replace( '\\', '/', self::$info[ $key ] );
+        $path = wp_normalize_path( self::$info[ $key ] );
 
         return $path;
     }


### PR DESCRIPTION
I couldn't have the export to "Github Pages" functionnal in the 6.6.7 version because of this line missing. It tooks me two days to find the issue, and one change to have it works. I know your code better now, it's a really good work !