### PR TITLE
Fix job queueing when a post is saved or trashed.

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -395,15 +395,16 @@ class Controller {
     }
 
     public static function wp2static_save_post_handler( int $post_id ) : void {
-        if ( get_post_status( $post_id ) !== 'publish' ) {
-            return;
+        if ( CoreOptions::getValue( 'queueJobOnPostSave' ) &&
+             get_post_status( $post_id ) === 'publish' ) {
+            self::wp2static_enqueue_jobs();
         }
-
-        self::wp2static_enqueue_jobs();
     }
 
     public static function wp2static_trashed_post_handler() : void {
-        self::wp2static_enqueue_jobs();
+        if ( CoreOptions::getValue( 'queueJobOnPostDelete' ) ) {
+            self::wp2static_enqueue_jobs();
+        }
     }
 
     public static function wp2static_enqueue_jobs() : void {

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -421,34 +421,6 @@ class CoreOptions {
                     [ 'name' => 'queueJobOnPostDelete' ]
                 );
 
-                if ( $queue_on_post_save ) {
-                    add_action(
-                        'save_post',
-                        [ 'WP2Static\Controller', 'wp2static_save_post_handler' ],
-                        0
-                    );
-                } else {
-                    remove_action(
-                        'save_post',
-                        [ 'WP2Static\Controller', 'wp2static_save_post_handler' ],
-                        0
-                    );
-                }
-
-                if ( $queue_on_post_delete ) {
-                    add_action(
-                        'trashed_post',
-                        [ 'WP2Static\Controller', 'wp2static_trashed_post_handler' ],
-                        0
-                    );
-                } else {
-                    remove_action(
-                        'trashed_post',
-                        [ 'WP2Static\Controller', 'wp2static_trashed_post_handler' ],
-                        0
-                    );
-                }
-
                 $process_queue_interval =
                     isset( $_POST['processQueueInterval'] ) ?
                      $_POST['processQueueInterval'] : 0;

--- a/src/WordPressAdmin.php
+++ b/src/WordPressAdmin.php
@@ -185,6 +185,18 @@ class WordPressAdmin {
             1
         );
 
+        add_action(
+            'save_post',
+            [ 'WP2Static\Controller', 'wp2static_save_post_handler' ],
+            0
+        );
+
+        add_action(
+            'trashed_post',
+            [ 'WP2Static\Controller', 'wp2static_trashed_post_handler' ],
+            0
+        );
+
         /*
          * Register actions for when we should invalidate cache for
          * a URL(s) or whole site


### PR DESCRIPTION
This fixes a regression introduced in 09847fdc92faa82ab4ddd9375b17aaebb1aec580,
but rather than simply revert the relevant changes made there, I opted to
move the calls to CoreOptions::getValue into the handlers, so they will
only hit the DB when the hooks fire, rather than potentially every page load.

Fixes #544.