### PR TITLE
Filter to change filenames_to_ignore

### DIFF
--- a/src/FilesHelper.php
+++ b/src/FilesHelper.php
@@ -128,6 +128,8 @@ class FilesHelper {
             'wpallimport',
         ];
 
+        $filenames_to_ignore = apply_filters( 'wp2static_filenames_to_ignore', $filenames_to_ignore );
+
         $matches = 0;
 
         str_replace( $filenames_to_ignore, '', $file_name, $matches );


### PR DESCRIPTION
Added primarily to prevent detecting encryption keys for GitHub add-on.