### PR TITLE
Record redirects and add wp2static_list_redirects filter

### DIFF
--- a/src/CrawlCache.php
+++ b/src/CrawlCache.php
@@ -155,4 +155,21 @@ class CrawlCache {
 
         return $total;
     }
+
+    public static function wp2static_list_redirects( array $redirs ) {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wp2static_crawl_cache';
+
+        $rows = $wpdb->get_results( "SELECT url, redirect_to FROM $table_name WHERE 0 < LENGTH(redirect_to)" );
+
+        foreach ( $rows as $row ) {
+            array_push($redirs, [
+                'url' => $row->url,
+                'redirect_to' => $row->redirect_to,
+            ]);
+        }
+
+        return $redirs;
+    }
 }

--- a/src/CrawlCache.php
+++ b/src/CrawlCache.php
@@ -164,10 +164,10 @@ class CrawlCache {
         $rows = $wpdb->get_results( "SELECT url, redirect_to FROM $table_name WHERE 0 < LENGTH(redirect_to)" );
 
         foreach ( $rows as $row ) {
-            array_push($redirs, [
+            $redirs[$row->url] = [
                 'url' => $row->url,
                 'redirect_to' => $row->redirect_to,
-            ]);
+            ];
         }
 
         return $redirs;

--- a/src/CrawlCache.php
+++ b/src/CrawlCache.php
@@ -16,6 +16,8 @@ class CrawlCache {
             url VARCHAR(2083) NOT NULL,
             page_hash CHAR(32) NOT NULL,
             time datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+            status SMALLINT DEFAULT 200 NOT NULL,
+            redirect_to VARCHAR(2083) NULL,
             PRIMARY KEY  (hashed_url)
         ) $charset_collate;";
 
@@ -43,21 +45,26 @@ class CrawlCache {
         return $urls;
     }
 
-    public static function addUrl( string $url, string $page_hash ) : void {
+    public static function addUrl( string $url, string $page_hash, int $status,
+                                   ?string $redirect_to ) : void {
         global $wpdb;
 
         $table_name = $wpdb->prefix . 'wp2static_crawl_cache';
-        $sql = "insert into {$table_name} (time, hashed_url, url, page_hash)
-                VALUES (%s, %s, %s, %s) ON DUPLICATE KEY
-                UPDATE time = %s, page_hash = %s";
+        $sql = "insert into {$table_name} (time, hashed_url, url, page_hash, status, redirect_to)
+                VALUES (%s, %s, %s, %s, %s, %s) ON DUPLICATE KEY
+                UPDATE time = %s, page_hash = %s, status = %s, redirect_to = %s";
         $sql = $wpdb->prepare(
             $sql,
             current_time( 'mysql' ),
             md5( $url ),
             $url,
             $page_hash,
+            $status,
+            $redirect_to,
             current_time( 'mysql' ),
-            $page_hash
+            $page_hash,
+            $status,
+            $redirect_to,
         );
 
         $wpdb->query( $sql );

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -105,11 +105,11 @@ class Crawler {
 
             $response = $this->crawlURL( $url );
             $crawled_contents = $response['body'];
+            $redirect_to = null;
 
-            if ( $response['effective_url'] ) {
-                $response['effective_url'] = str_replace( $site_urls, '',
-                                                          $response['effective_url'] );
-                $page_hash = md5( $response['code'] . $response['effective_url'] );
+            if ( in_array( $response['code'], WP2STATIC_REDIRECT_CODES ) ) {
+                $redirect_to = str_replace( $site_urls, '', $response['effective_url'] );
+                $page_hash = md5( $response['code'] . $redirect_to );
             } else if ( ! is_null( $crawled_contents ) ) {
                 $page_hash = md5( $crawled_contents );
             } else {
@@ -139,7 +139,7 @@ class Crawler {
             }
 
             CrawlCache::addUrl( $root_relative_path, $page_hash, $response['code'],
-                                $response['effective_url'] );
+                                $redirect_to );
 
             // incrementally log crawl progress
             if ( $crawled % 300 === 0 ) {

--- a/src/Request.php
+++ b/src/Request.php
@@ -64,7 +64,7 @@ class Request {
             'body' => curl_exec( $ch ),
             'ch' => $ch,
             'code' => curl_getinfo( $ch, CURLINFO_RESPONSE_CODE ),
-
+            'effective_url' => curl_getinfo( $ch, CURLINFO_EFFECTIVE_URL ),
         ];
 
         return $response;

--- a/src/WordPressAdmin.php
+++ b/src/WordPressAdmin.php
@@ -41,6 +41,11 @@ class WordPressAdmin {
         );
 
         add_filter(
+            'wp2static_list_redirects',
+            [ 'WP2Static\CrawlCache', 'wp2static_list_redirects']
+        );
+
+        add_filter(
             'cron_request',
             [ 'WP2Static\WPCron', 'wp2static_cron_with_http_basic_auth' ]
         );


### PR DESCRIPTION
Closes #566.

This adds two columns to the crawl cache table: status and redirect_to. To record this information, the table is written to even if it is disabled for caching purposes.

Redirect targets are detected, but are not added to the crawl queue. This should happen, but it's probably better to handle that later on.

This adds a wp2static_list_redirects filter that takes and returns an array of redirects. The array is indexed by URL. Each redirect has the form ['url'=> '...', 'redirect_to' => '...']. Deployment addons can use this to get a list of redirects to create. Other addons can add redirects from other sources (.htaccess, redirection plugins, etc.)

Example of the wp2static_list_redirects array format:
```php
['/favicon.ico' =>
  ['url' => '/favicon.ico',
   'redirect_to' => '/wp-admin/images/w-logo-blue.png'],

 '/page/1/' =>
  ['url' => '/page/1/,
   'redirect_to' => '/']
]
```