### PR TITLE
WIP less detection, more discovery

### DIFF
--- a/src/URLDetector.php
+++ b/src/URLDetector.php
@@ -22,30 +22,13 @@ class URLDetector {
 
         $arrays_to_merge = [];
 
-        // TODO: detect robots.txt, etc before adding
         $arrays_to_merge[] = [
             '/',
-            '/robots.txt',
+            '/ads.txt',
             '/favicon.ico',
+            '/robots.txt',
             '/sitemap.xml',
         ];
-
-        /*
-            TODO: reimplement detection for URLs:
-                'detectCommentPagination',
-                'detectComments',
-                'detectFeedURLs',
-
-        // other options:
-
-         - robots
-         - favicon
-         - sitemaps
-
-        */
-        // if ( CoreOptions::getValue('detectAttachments') ) {
-        // $arrays_to_merge[] = DetectAttachmentURLs::detect();
-        // }
 
         if ( CoreOptions::getValue( 'detectPosts' ) ) {
             $permalink_structure = get_option( 'permalink_structure' );
@@ -60,46 +43,8 @@ class URLDetector {
             $arrays_to_merge[] = DetectCustomPostTypeURLs::detect();
         }
 
-        if ( CoreOptions::getValue( 'detectUploads' ) ) {
-            $arrays_to_merge[] =
-                FilesHelper::getListOfLocalFilesByDir( SiteInfo::getPath( 'uploads' ) );
-        }
-
-        $detect_parent_theme = apply_filters( 'wp2static_detect_parent_theme', 1 );
-
-        if ( $detect_parent_theme ) {
-            $arrays_to_merge[] = DetectThemeAssets::detect( 'parent' );
-        }
-
-        $detect_child_theme = apply_filters( 'wp2static_detect_child_theme', 1 );
-
-        if ( $detect_child_theme ) {
-            $arrays_to_merge[] = DetectThemeAssets::detect( 'child' );
-        }
-
-        $detect_plugin_assets = apply_filters( 'wp2static_detect_plugin_assets', 1 );
-
-        if ( $detect_plugin_assets ) {
-            $arrays_to_merge[] = DetectPluginAssets::detect();
-        }
-
-        $detect_wpinc_assets = apply_filters( 'wp2static_detect_wpinc_assets', 1 );
-
-        if ( $detect_wpinc_assets ) {
-            $arrays_to_merge[] = DetectWPIncludesAssets::detect();
-        }
-
-        $detect_vendor_cache = apply_filters( 'wp2static_detect_vendor_cache', 1 );
-
-        if ( $detect_vendor_cache ) {
-            $arrays_to_merge[] = DetectVendorFiles::detect( SiteInfo::getURL( 'site' ) );
-        }
-
-        $detect_posts_pagination = apply_filters( 'wp2static_detect_posts_pagination', 1 );
-
-        if ( $detect_posts_pagination ) {
-            $arrays_to_merge[] = DetectPostsPaginationURLs::detect();
-        }
+        // TODO: bring in detectVendorFiles() from V6 (Yoast sitemaps,
+        // probably drop custom permalinks plugin support now)
 
         $detect_archives = apply_filters( 'wp2static_detect_archives', 1 );
 
@@ -111,12 +56,6 @@ class URLDetector {
 
         if ( $detect_categories ) {
             $arrays_to_merge[] = DetectCategoryURLs::detect( SiteInfo::getUrl( 'site' ) );
-        }
-
-        $detect_category_pagination = apply_filters( 'wp2static_detect_category_pagination', 1 );
-
-        if ( $detect_category_pagination ) {
-            $arrays_to_merge[] = DetectCategoryPaginationURLs::detect( SiteInfo::getUrl( 'site' ) );
         }
 
         $url_queue = call_user_func_array( 'array_merge', $arrays_to_merge );


### PR DESCRIPTION
this will borrow some of the recent changes in Static HTML Output, to no longer try and detect every single URL and file from WP and take too much - rather, we'll just detect the main pages/posts/starting points we need and then continuously crawl the whole site, discovering additional URLs as we go. 

I knew this task was coming up, but when I started looking at WP2Static code again tonight and doing a test deploy, it was picking up *waaaaay* too many useless vendor files from composer-based plugins, making crawl take forever and server run wild. So, I'll make this adjustment as preparing some new builds to get us all using latest add-ons 