### PR TITLE
Add page wrappers to for consistent admin styling

### DIFF
--- a/views/addons-page.php
+++ b/views/addons-page.php
@@ -1,57 +1,58 @@
-<br>
+<div class="wrap">
+    <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>Enabled</th>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Documentation URL</th>
-            <th>Configure</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php if ( ! $view['addons'] ) : ?>
+    <table class="widefat striped">
+        <thead>
             <tr>
-                <td colspan="4">No addons are installed. <a href="https://wp2static.com/download">Get Add-Ons</a></td>
+                <th>Enabled</th>
+                <th>Name</th>
+                <th>Type</th>
+                <th>Documentation URL</th>
+                <th>Configure</th>
             </tr>
-        <?php endif; ?>
+        </thead>
+        <tbody>
+            <?php if ( ! $view['addons'] ) : ?>
+                <tr>
+                    <td colspan="4">No addons are installed. <a href="https://wp2static.com/download">Get Add-Ons</a></td>
+                </tr>
+            <?php endif; ?>
 
 
-        <?php foreach( $view['addons'] as $addon ) : ?>
-            <tr>
-                <td>
-                    <form
-                        name="wp2static-crawl-queue-delete"
-                        method="POST"
-                        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+            <?php foreach( $view['addons'] as $addon ) : ?>
+                <tr>
+                    <td>
+                        <form
+                            name="wp2static-crawl-queue-delete"
+                            method="POST"
+                            action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
 
-                    <?php wp_nonce_field( $view['nonce_action'] ); ?>
-                    <input name="action" type="hidden" value="wp2static_toggle_addon" />
-                    <input name="addon_slug" type="hidden" value="<?php echo $addon->slug; ?>" />
+                        <?php wp_nonce_field( $view['nonce_action'] ); ?>
+                        <input name="action" type="hidden" value="wp2static_toggle_addon" />
+                        <input name="addon_slug" type="hidden" value="<?php echo $addon->slug; ?>" />
 
-                    <button><?php echo $addon->enabled ? 'Enabled' : 'Disabled'; ?></button>
+                        <button><?php echo $addon->enabled ? 'Enabled' : 'Disabled'; ?></button>
 
-                    </form>
+                        </form>
 
-                </td>
-                <td>
-                    <?php echo $addon->name; ?>
-                    <br>
-                    <?php echo $addon->description; ?>
-                </td>
-                <td><?php echo $addon->type; ?></td>
-                <td>
-                    <a href="<?php echo $addon->docs_url; ?>"><span class="dashicons dashicons-book-alt"></span></a>
-                </td>
-                <td>
-                    <a href="<?php echo esc_url( admin_url("admin.php?page={$addon->slug}") ); ?>"><span class="dashicons dashicons-admin-generic"></span></a>
-                </td>
+                    </td>
+                    <td>
+                        <?php echo $addon->name; ?>
+                        <br>
+                        <?php echo $addon->description; ?>
+                    </td>
+                    <td><?php echo $addon->type; ?></td>
+                    <td>
+                        <a href="<?php echo $addon->docs_url; ?>"><span class="dashicons dashicons-book-alt"></span></a>
+                    </td>
+                    <td>
+                        <a href="<?php echo esc_url( admin_url("admin.php?page={$addon->slug}") ); ?>"><span class="dashicons dashicons-admin-generic"></span></a>
+                    </td>
 
-            </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
 
-<br> 
-
+    <br>
+</div>

--- a/views/caches-page.php
+++ b/views/caches-page.php
@@ -5,137 +5,119 @@ button.wp2static-button {
 }
 </style>
 
-<p><i><a href="<?php echo admin_url('admin.php?page=wp2static-caches'); ?>">Refresh page</a> to see latest status</i><p>
+<div class="wrap">
+    <p><i><a href="<?php echo admin_url('admin.php?page=wp2static-caches'); ?>">Refresh page</a> to see latest status</i><p>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>Cache Type</th>
-            <th>Statistics</th>
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>Crawl Queue (Detected URLs)</td>
-            <td><?php echo $view['crawlQueueTotalURLs']; ?> URLs in database</td>
-            <td>
-                <a href="<?php echo admin_url('admin.php?page=wp2static-crawl-queue'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show URLs</button></a>
-<!-- TODO: allow downloading zipped CSV of all lists  <a href="#"><button class="wp2static-button button btn-danger">Download List</button></a> -->
-
-                <form
-                    name="wp2static-crawl-queue-delete"
-                    method="POST"
-                    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
-
-                <?php wp_nonce_field( $view['nonce_action'] ); ?>
-                <input name="action" type="hidden" value="wp2static_crawl_queue_delete" />
-
-                <button class="wp2static-button button btn-danger">Delete Crawl Queue</button>
-
-                </form>
-            </td>
-        </tr>
-        <tr>
-            <td>Crawl Cache</td>
-            <td><?php echo $view['crawlCacheTotalURLs']; ?> URLs in database</td>
-            <td>
-                <a href="<?php echo admin_url('admin.php?page=wp2static-crawl-cache'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show URLs</button></a>
-
-                <form
-                    name="wp2static-crawl-cache-delete"
-                    method="POST"
-                    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
-
-                <?php wp_nonce_field( $view['nonce_action'] ); ?>
-                <input name="action" type="hidden" value="wp2static_crawl_cache_delete" />
-
-                <button class="wp2static-button button btn-danger">Delete Crawl Cache</button>
-
-                </form>
-            </td>
-        </tr>
-        <tr>
-            <td>Generated Static Site</td>
-            <td><?php echo $view['exportedSiteFileCount']; ?> files, using <?php echo $view['exportedSiteDiskSpace']; ?>
-                <br>
-
-                <a href="file://<?php echo $view['uploads_path']; ?>wp2static-exported-site" />Path</a>
-
-            </td>
-            <td>
-                <a href="<?php echo admin_url('admin.php?page=wp2static-static-site'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show Paths</button></a>
-
-                <form
-                    name="wp2static-static-site-delete"
-                    method="POST"
-                    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
-
-                <?php wp_nonce_field( $view['nonce_action'] ); ?>
-                <input name="action" type="hidden" value="wp2static_static_site_delete" />
-
-                <button class="wp2static-button button btn-danger">Delete Files</button>
-
-                </form>
-            </td>
-        </tr>
-        <tr>
-            <td>Post-processed Static Site</td>
-            <td><?php echo $view['processedSiteFileCount']; ?> files, using <?php echo $view['processedSiteDiskSpace']; ?>
-                <br>
-
-                <a href="file://<?php echo $view['uploads_path']; ?>wp2static-processed-site" />Path</a>
-            </td>
-            <td>
-                <a href="<?php echo admin_url('admin.php?page=wp2static-post-processed-site'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show Paths</button></a>
-
-                <form
-                    name="wp2static-post-processed-site-delete"
-                    method="POST"
-                    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
-
-                <?php wp_nonce_field( $view['nonce_action'] ); ?>
-                <input name="action" type="hidden" value="wp2static_post_processed_site_delete" />
-
-                <button class="wp2static-button button btn-danger">Delete Files</button>
-
-                </form>
-            </td>
-        </tr>
-
-        <?php
-        $deploy_cache_rows
-            = isset($view['deployCacheTotalPathsByNamespace'])
-            ? count($view['deployCacheTotalPathsByNamespace'])
-            : 1
-        ;
-        ?>
-        <tr>
-            <td rowspan="<?php echo $deploy_cache_rows; ?>">Deploy Cache</td>
-            <?php if ( isset($view['deployCacheTotalPathsByNamespace']) ) : ?>
-                <?php $namespaces = array_keys($view['deployCacheTotalPathsByNamespace']); ?>
-                <td><?php echo $view['deployCacheTotalPathsByNamespace'][$namespaces[0]]; ?> Paths in database for <code><?php echo $namespaces[0]; ?></code></td>
+    <table class="widefat striped">
+        <thead>
+            <tr>
+                <th>Cache Type</th>
+                <th>Statistics</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Crawl Queue (Detected URLs)</td>
+                <td><?php echo $view['crawlQueueTotalURLs']; ?> URLs in database</td>
                 <td>
-                    <a href="<?php echo admin_url('admin.php?page=wp2static-deploy-cache&deploy_namespace=' . urlencode($namespaces[0])); ?>" target="_blank"><button class="wp2static-button button">Show Paths</button></a>
+                    <a href="<?php echo admin_url('admin.php?page=wp2static-crawl-queue'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show URLs</button></a>
+    <!-- TODO: allow downloading zipped CSV of all lists  <a href="#"><button class="wp2static-button button btn-danger">Download List</button></a> -->
+
                     <form
-                        name="wp2static-deploy-cache-delete"
+                        name="wp2static-crawl-queue-delete"
                         method="POST"
                         action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
 
                     <?php wp_nonce_field( $view['nonce_action'] ); ?>
-                    <input name="action" type="hidden" value="wp2static_deploy_cache_delete" />
-                    <input name="deploy_namespace" type="hidden" value="<?php echo $namespaces[0]; ?>" />
+                    <input name="action" type="hidden" value="wp2static_crawl_queue_delete" />
 
-                    <button class="wp2static-button button btn-danger">Delete Deploy Cache</button>
+                    <button class="wp2static-button button btn-danger">Delete Crawl Queue</button>
 
                     </form>
                 </td>
-                <?php for ( $i = 1; $i < $deploy_cache_rows; $i++ ) : ?>
-                    </tr>
-                    <tr>
-                    <td><?php echo $view['deployCacheTotalPathsByNamespace'][$namespaces[$i]]; ?> Paths in database for <code><?php echo $namespaces[$i]; ?></code></td>
+            </tr>
+            <tr>
+                <td>Crawl Cache</td>
+                <td><?php echo $view['crawlCacheTotalURLs']; ?> URLs in database</td>
+                <td>
+                    <a href="<?php echo admin_url('admin.php?page=wp2static-crawl-cache'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show URLs</button></a>
+
+                    <form
+                        name="wp2static-crawl-cache-delete"
+                        method="POST"
+                        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+
+                    <?php wp_nonce_field( $view['nonce_action'] ); ?>
+                    <input name="action" type="hidden" value="wp2static_crawl_cache_delete" />
+
+                    <button class="wp2static-button button btn-danger">Delete Crawl Cache</button>
+
+                    </form>
+                </td>
+            </tr>
+            <tr>
+                <td>Generated Static Site</td>
+                <td><?php echo $view['exportedSiteFileCount']; ?> files, using <?php echo $view['exportedSiteDiskSpace']; ?>
+                    <br>
+
+                    <a href="file://<?php echo $view['uploads_path']; ?>wp2static-exported-site" />Path</a>
+
+                </td>
+                <td>
+                    <a href="<?php echo admin_url('admin.php?page=wp2static-static-site'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show Paths</button></a>
+
+                    <form
+                        name="wp2static-static-site-delete"
+                        method="POST"
+                        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+
+                    <?php wp_nonce_field( $view['nonce_action'] ); ?>
+                    <input name="action" type="hidden" value="wp2static_static_site_delete" />
+
+                    <button class="wp2static-button button btn-danger">Delete Files</button>
+
+                    </form>
+                </td>
+            </tr>
+            <tr>
+                <td>Post-processed Static Site</td>
+                <td><?php echo $view['processedSiteFileCount']; ?> files, using <?php echo $view['processedSiteDiskSpace']; ?>
+                    <br>
+
+                    <a href="file://<?php echo $view['uploads_path']; ?>wp2static-processed-site" />Path</a>
+                </td>
+                <td>
+                    <a href="<?php echo admin_url('admin.php?page=wp2static-post-processed-site'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show Paths</button></a>
+
+                    <form
+                        name="wp2static-post-processed-site-delete"
+                        method="POST"
+                        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+
+                    <?php wp_nonce_field( $view['nonce_action'] ); ?>
+                    <input name="action" type="hidden" value="wp2static_post_processed_site_delete" />
+
+                    <button class="wp2static-button button btn-danger">Delete Files</button>
+
+                    </form>
+                </td>
+            </tr>
+
+            <?php
+            $deploy_cache_rows
+                = isset($view['deployCacheTotalPathsByNamespace'])
+                ? count($view['deployCacheTotalPathsByNamespace'])
+                : 1
+            ;
+            ?>
+            <tr>
+                <td rowspan="<?php echo $deploy_cache_rows; ?>">Deploy Cache</td>
+                <?php if ( isset($view['deployCacheTotalPathsByNamespace']) ) : ?>
+                    <?php $namespaces = array_keys($view['deployCacheTotalPathsByNamespace']); ?>
+                    <td><?php echo $view['deployCacheTotalPathsByNamespace'][$namespaces[0]]; ?> Paths in database for <code><?php echo $namespaces[0]; ?></code></td>
                     <td>
-                        <a href="<?php echo admin_url('admin.php?page=wp2static-deploy-cache&deploy_namespace=' . urlencode($namespaces[$i])); ?>" target="_blank"><button class="wp2static-button button">Show Paths</button></a>
+                        <a href="<?php echo admin_url('admin.php?page=wp2static-deploy-cache&deploy_namespace=' . urlencode($namespaces[0])); ?>" target="_blank"><button class="wp2static-button button">Show Paths</button></a>
                         <form
                             name="wp2static-deploy-cache-delete"
                             method="POST"
@@ -143,45 +125,65 @@ button.wp2static-button {
 
                         <?php wp_nonce_field( $view['nonce_action'] ); ?>
                         <input name="action" type="hidden" value="wp2static_deploy_cache_delete" />
-                        <input name="deploy_namespace" type="hidden" value="<?php echo $namespaces[$i]; ?>" />
+                        <input name="deploy_namespace" type="hidden" value="<?php echo $namespaces[0]; ?>" />
 
                         <button class="wp2static-button button btn-danger">Delete Deploy Cache</button>
 
                         </form>
                     </td>
-                <?php endfor; ?>
-            <?php else : ?>
-                <td><?php echo $view['deployCacheTotalPaths']; ?> Paths in database</td>
-                <td>
-                    <a href="<?php echo admin_url('admin.php?page=wp2static-deploy-cache'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show Paths</button></a>
+                    <?php for ( $i = 1; $i < $deploy_cache_rows; $i++ ) : ?>
+                        </tr>
+                        <tr>
+                        <td><?php echo $view['deployCacheTotalPathsByNamespace'][$namespaces[$i]]; ?> Paths in database for <code><?php echo $namespaces[$i]; ?></code></td>
+                        <td>
+                            <a href="<?php echo admin_url('admin.php?page=wp2static-deploy-cache&deploy_namespace=' . urlencode($namespaces[$i])); ?>" target="_blank"><button class="wp2static-button button">Show Paths</button></a>
+                            <form
+                                name="wp2static-deploy-cache-delete"
+                                method="POST"
+                                action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
 
-                    <form
-                        name="wp2static-deploy-cache-delete"
-                        method="POST"
-                        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+                            <?php wp_nonce_field( $view['nonce_action'] ); ?>
+                            <input name="action" type="hidden" value="wp2static_deploy_cache_delete" />
+                            <input name="deploy_namespace" type="hidden" value="<?php echo $namespaces[$i]; ?>" />
 
-                    <?php wp_nonce_field( $view['nonce_action'] ); ?>
-                    <input name="action" type="hidden" value="wp2static_deploy_cache_delete" />
+                            <button class="wp2static-button button btn-danger">Delete Deploy Cache</button>
 
-                    <button class="wp2static-button button btn-danger">Delete Deploy Cache</button>
+                            </form>
+                        </td>
+                    <?php endfor; ?>
+                <?php else : ?>
+                    <td><?php echo $view['deployCacheTotalPaths']; ?> Paths in database</td>
+                    <td>
+                        <a href="<?php echo admin_url('admin.php?page=wp2static-deploy-cache'); ?>" target="_blank"><button class="wp2static-button button btn-danger">Show Paths</button></a>
 
-                    </form>
-                </td>
-            <?php endif; ?>
-        </tr>
-    </tbody>
-</table>
+                        <form
+                            name="wp2static-deploy-cache-delete"
+                            method="POST"
+                            action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
 
-<br>
+                        <?php wp_nonce_field( $view['nonce_action'] ); ?>
+                        <input name="action" type="hidden" value="wp2static_deploy_cache_delete" />
 
-<form
-    name="wp2static-delete-all-caches"
-    method="POST"
-    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+                        <button class="wp2static-button button btn-danger">Delete Deploy Cache</button>
 
-<?php wp_nonce_field( $view['nonce_action'] ); ?>
-<input name="action" type="hidden" value="wp2static_delete_all_caches" />
+                        </form>
+                    </td>
+                <?php endif; ?>
+            </tr>
+        </tbody>
+    </table>
 
-<button class="wp2static-button button btn-danger">Delete all caches</button>
+    <br>
 
-</form>
+    <form
+        name="wp2static-delete-all-caches"
+        method="POST"
+        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+
+    <?php wp_nonce_field( $view['nonce_action'] ); ?>
+    <input name="action" type="hidden" value="wp2static_delete_all_caches" />
+
+    <button class="wp2static-button button btn-danger">Delete all caches</button>
+
+    </form>
+</div>

--- a/views/crawl-cache-page.php
+++ b/views/crawl-cache-page.php
@@ -1,24 +1,26 @@
-<br>
+<div class="wrap">
+    <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>URLs in Crawl Cache</th>
-	          <th>Page MD5 Hash</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php if ( ! $view['urls'] ) : ?>
+    <table class="widefat striped">
+        <thead>
             <tr>
-                <td colspan="2">Crawl cache is empty.</td>
+                <th>URLs in Crawl Cache</th>
+                <th>Page MD5 Hash</th>
             </tr>
-        <?php endif; ?>
+        </thead>
+        <tbody>
+            <?php if ( ! $view['urls'] ) : ?>
+                <tr>
+                    <td colspan="2">Crawl cache is empty.</td>
+                </tr>
+            <?php endif; ?>
 
-        <?php foreach( $view['urls'] as $url=>$page_hash ) : ?>
-            <tr>
-                <td><?php echo $url; ?></td>
-		<td><?php echo $page_hash; ?></td>
-            </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
+            <?php foreach( $view['urls'] as $url=>$page_hash ) : ?>
+                <tr>
+                    <td><?php echo $url; ?></td>
+            <td><?php echo $page_hash; ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/views/crawl-queue-page.php
+++ b/views/crawl-queue-page.php
@@ -1,23 +1,24 @@
-<br>
+<div class="wrap">
+    <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>URLs in Crawl Queue</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php if ( ! $view['urls'] ) : ?>
+    <table class="widefat striped">
+        <thead>
             <tr>
-                <td>Crawl queue is empty.</td>
+                <th>URLs in Crawl Queue</th>
             </tr>
-        <?php endif; ?>
+        </thead>
+        <tbody>
+            <?php if ( ! $view['urls'] ) : ?>
+                <tr>
+                    <td>Crawl queue is empty.</td>
+                </tr>
+            <?php endif; ?>
 
-        <?php foreach( $view['urls'] as $url ) : ?>
-            <tr>
-                <td><?php echo $url; ?></td>
-            </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
-
+            <?php foreach( $view['urls'] as $url ) : ?>
+                <tr>
+                    <td><?php echo $url; ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/views/deploy-cache-page.php
+++ b/views/deploy-cache-page.php
@@ -1,23 +1,24 @@
-<br>
+<div class="wrap">
+    <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>Path in Deploy Cache</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php if ( ! $view['paths'] ) : ?>
+    <table class="widefat striped">
+        <thead>
             <tr>
-                <td>Deploy Cache is empty.</td>
+                <th>Path in Deploy Cache</th>
             </tr>
-        <?php endif; ?>
+        </thead>
+        <tbody>
+            <?php if ( ! $view['paths'] ) : ?>
+                <tr>
+                    <td>Deploy Cache is empty.</td>
+                </tr>
+            <?php endif; ?>
 
-        <?php foreach( $view['paths'] as $path ) : ?>
-            <tr>
-                <td><?php echo $path; ?></td>
-            </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
-
+            <?php foreach( $view['paths'] as $path ) : ?>
+                <tr>
+                    <td><?php echo $path; ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/views/diagnostics-page.php
+++ b/views/diagnostics-page.php
@@ -1,173 +1,175 @@
-<br>
+<div class="wrap">
+    <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>Health check</th>
-            <th>Status</th>
-            <th>Advice</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>PHP max_execution_time</td>
-            <td>
-                <?php echo $view['maxExecutionTime'] == 0 ? 'Unlimited' : $view['maxExecutionTime'] . ' secs'; ?>
+    <table class="widefat striped">
+        <thead>
+            <tr>
+                <th>Health check</th>
+                <th>Status</th>
+                <th>Advice</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>PHP max_execution_time</td>
+                <td>
+                    <?php echo $view['maxExecutionTime'] == 0 ? 'Unlimited' : $view['maxExecutionTime'] . ' secs'; ?>
 
-                <span
-                    class="dashicons <?php echo $view['maxExecutionTime'] == 0 ? 'dashicons-yes' : 'dashicons-no'; ?>"
-                    style="color: <?php echo $view['maxExecutionTime'] == 0 ? 'green' : 'red'; ?>;"
-                ></span>
-            </td>
-            <td>Generating a static site can involve long-running processes. Set your PHP max_execution_time setting to unlimited or find a better webhost if you're prevented from doing so.</td>
-        </tr>
-        <tr>
-            <td>PHP memory_limit</td>
-            <td>
-                <?php echo $view['memoryLimit']; ?>
+                    <span
+                        class="dashicons <?php echo $view['maxExecutionTime'] == 0 ? 'dashicons-yes' : 'dashicons-no'; ?>"
+                        style="color: <?php echo $view['maxExecutionTime'] == 0 ? 'green' : 'red'; ?>;"
+                    ></span>
+                </td>
+                <td>Generating a static site can involve long-running processes. Set your PHP max_execution_time setting to unlimited or find a better webhost if you're prevented from doing so.</td>
+            </tr>
+            <tr>
+                <td>PHP memory_limit</td>
+                <td>
+                    <?php echo $view['memoryLimit']; ?>
 
-            </td>
-            <td>WP2Static will use as much memory as is available to it during processing. Allocating more of your system RAM to PHP should improve performance.</td>
-        </tr>
-        <tr>
-            <td>Uploads directory writable</td>
-            <td>
-                <?php echo $view['uploadsWritable']  ? 'Writable' : 'Non-writable'; ?>
+                </td>
+                <td>WP2Static will use as much memory as is available to it during processing. Allocating more of your system RAM to PHP should improve performance.</td>
+            </tr>
+            <tr>
+                <td>Uploads directory writable</td>
+                <td>
+                    <?php echo $view['uploadsWritable']  ? 'Writable' : 'Non-writable'; ?>
 
-                <span
-                    class="dashicons <?php echo $view['uploadsWritable'] ? 'dashicons-yes' : 'dashicons-no'; ?>"
-                    style="color: <?php echo $view['uploadsWritable'] ? 'green' : 'red'; ?>;"
-                ></span>
-            </td>
-            <td>Generating a static site can involve long-running processes. Set your PHP max_execution_time setting to unlimited or find a better webhost if you're prevented from doing so.</td>
-        </tr>
-        <tr>
-            <td>PHP version</td>
-            <td>
-                <?php echo PHP_VERSION; ?>
+                    <span
+                        class="dashicons <?php echo $view['uploadsWritable'] ? 'dashicons-yes' : 'dashicons-no'; ?>"
+                        style="color: <?php echo $view['uploadsWritable'] ? 'green' : 'red'; ?>;"
+                    ></span>
+                </td>
+                <td>Generating a static site can involve long-running processes. Set your PHP max_execution_time setting to unlimited or find a better webhost if you're prevented from doing so.</td>
+            </tr>
+            <tr>
+                <td>PHP version</td>
+                <td>
+                    <?php echo PHP_VERSION; ?>
 
-                <span
-                    class="dashicons <?php echo ! $view['phpOutOfDate'] ? 'dashicons-yes' : 'dashicons-no'; ?>"
-                    style="color: <?php echo ! $view['phpOutOfDate'] ? 'green' : 'red'; ?>;"
-                ></span>
-            </td>
-            <td>
-              <p>The current officially supported PHP versions can be found on <a href="http://php.net/supported-versions.php" target="_blank">PHP.net</a></p>
+                    <span
+                        class="dashicons <?php echo ! $view['phpOutOfDate'] ? 'dashicons-yes' : 'dashicons-no'; ?>"
+                        style="color: <?php echo ! $view['phpOutOfDate'] ? 'green' : 'red'; ?>;"
+                    ></span>
+                </td>
+                <td>
+                <p>The current officially supported PHP versions can be found on <a href="http://php.net/supported-versions.php" target="_blank">PHP.net</a></p>
 
-              <p>WP2Static now requires a minimum of PHP 7.3 and recommends PHP 7.4 for better performance. If your hosting provider doesn't provide PHP 7.4 or at least PHP 7.3, find a better one!</p>
-            </td>
-        </tr>
-        <tr>
-            <td>cURL extension loaded</td>
-            <td>
-                <?php echo $view['curlSupported'] ? 'Yes' : 'No'; ?>
+                <p>WP2Static now requires a minimum of PHP 7.3 and recommends PHP 7.4 for better performance. If your hosting provider doesn't provide PHP 7.4 or at least PHP 7.3, find a better one!</p>
+                </td>
+            </tr>
+            <tr>
+                <td>cURL extension loaded</td>
+                <td>
+                    <?php echo $view['curlSupported'] ? 'Yes' : 'No'; ?>
 
-                <span
-                    class="dashicons <?php echo $view['curlSupported'] ? 'dashicons-yes' : 'dashicons-no'; ?>"
-                    style="color: <?php echo $view['curlSupported'] ? 'green' : 'red'; ?>;"
-                ></span>
-            </td>
-            <td>
-                <p>You need the cURL extension enabled on your web server</p>
+                    <span
+                        class="dashicons <?php echo $view['curlSupported'] ? 'dashicons-yes' : 'dashicons-no'; ?>"
+                        style="color: <?php echo $view['curlSupported'] ? 'green' : 'red'; ?>;"
+                    ></span>
+                </td>
+                <td>
+                    <p>You need the cURL extension enabled on your web server</p>
 
-                <p> This is a library that allows the plugin to better export your static site out to services like GitHub, S3, Dropbox, BunnyCDN, etc. It's usually an easy fix to get this working. You can try Googling "How to enable cURL extension for PHP", along with the name of the environment you are using to run your WordPress site. This may be something like DigitalOcean, GoDaddy or LAMP, MAMP, WAMP for your webserver on your local computer. If you're still having trouble, the developer of this plugin is easger to help you get up and running. Please ask for help on our <a href="https://forum.wp2static.com">forum</a>.</p>
-            </td>
-        </tr>
-        <tr>
-            <td>WordPress Permalinks Defined</td>
-            <td>
-                <?php echo $view['permalinksDefined'] ? 'Yes' : 'No'; ?>
+                    <p> This is a library that allows the plugin to better export your static site out to services like GitHub, S3, Dropbox, BunnyCDN, etc. It's usually an easy fix to get this working. You can try Googling "How to enable cURL extension for PHP", along with the name of the environment you are using to run your WordPress site. This may be something like DigitalOcean, GoDaddy or LAMP, MAMP, WAMP for your webserver on your local computer. If you're still having trouble, the developer of this plugin is easger to help you get up and running. Please ask for help on our <a href="https://forum.wp2static.com">forum</a>.</p>
+                </td>
+            </tr>
+            <tr>
+                <td>WordPress Permalinks Defined</td>
+                <td>
+                    <?php echo $view['permalinksDefined'] ? 'Yes' : 'No'; ?>
 
-                <span
-                    class="dashicons <?php echo $view['permalinksDefined'] ? 'dashicons-yes' : 'dashicons-no'; ?>"
-                    style="color: <?php echo $view['permalinksDefined'] ? 'green' : 'red'; ?>;"
-                ></span>
-            </td>
-            <td>
-                <p>Due to the nature of how static sites work, you'll need to have some kind of permalinks structure defined in your <a href="<?php echo admin_url( 'options-permalink.php' ); ?>">Permalink Settings</a> within WordPress. To learn more on how to do this, please see WordPress's official guide to the <a href="https://codex.wordpress.org/Settings_Permalinks_Screen">Settings Permalinks Screen</a>.</p>
-            </td>
-        </tr>
-    </tbody>
-</table>
+                    <span
+                        class="dashicons <?php echo $view['permalinksDefined'] ? 'dashicons-yes' : 'dashicons-no'; ?>"
+                        style="color: <?php echo $view['permalinksDefined'] ? 'green' : 'red'; ?>;"
+                    ></span>
+                </td>
+                <td>
+                    <p>Due to the nature of how static sites work, you'll need to have some kind of permalinks structure defined in your <a href="<?php echo admin_url( 'options-permalink.php' ); ?>">Permalink Settings</a> within WordPress. To learn more on how to do this, please see WordPress's official guide to the <a href="https://codex.wordpress.org/Settings_Permalinks_Screen">Settings Permalinks Screen</a>.</p>
+                </td>
+            </tr>
+        </tbody>
+    </table>
 
 
-<h4>Loaded PHP extensions</h4>
+    <h4>Loaded PHP extensions</h4>
 
-<table class="widefat striped">
-    <tbody>
+    <table class="widefat striped">
+        <tbody>
 
-<?php
-natcasesort($view['extensions']);
-$ar_list = $view['extensions'];
-$rows = ceil(count($ar_list) / 5);
-$lists  = array_chunk($ar_list, $rows);
+    <?php
+    natcasesort($view['extensions']);
+    $ar_list = $view['extensions'];
+    $rows = ceil(count($ar_list) / 5);
+    $lists  = array_chunk($ar_list, $rows);
 
-foreach ( $lists as $column) {
-    echo '<tr>';
-    foreach ($column as $item) {
-        echo '<td>' . $item . '</td>';
+    foreach ( $lists as $column) {
+        echo '<tr>';
+        foreach ($column as $item) {
+            echo '<td>' . $item . '</td>';
+        }
+        echo '</tr>';
     }
-    echo '</tr>';
-}
 
-?>
-    </tbody>
-</table>
+    ?>
+        </tbody>
+    </table>
 
-<h4>WP2Static Core Options</h4>
+    <h4>WP2Static Core Options</h4>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Value</th>
-        </tr>
-    </thead>
-    <tbody>
+    <table class="widefat striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
 
-        <?php foreach ( $view['coreOptions'] as $option) : ?>
+            <?php foreach ( $view['coreOptions'] as $option) : ?>
 
-           <tr>
-           <td><?php echo $option['label'];?></td>
-           <td><?php echo $option['value'];?></td>
-           </tr>
+            <tr>
+            <td><?php echo $option['label'];?></td>
+            <td><?php echo $option['value'];?></td>
+            </tr>
 
-        <?php endforeach; ?>
+            <?php endforeach; ?>
 
-    </tbody>
-</table>
+        </tbody>
+    </table>
 
-<h4>WordPress Site Info</h4>
+    <h4>WordPress Site Info</h4>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Value</th>
-        </tr>
-    </thead>
-    <tbody>
+    <table class="widefat striped">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
 
-        <?php
-        // TODO: sort site infos alpha
-        foreach ( $view['site_info'] as $name => $value) : ?>
-           <tr>
-           <td><?php echo $name;?></td>
-           <td><?php echo $value;?></td>
-           </tr>
+            <?php
+            // TODO: sort site infos alpha
+            foreach ( $view['site_info'] as $name => $value) : ?>
+            <tr>
+            <td><?php echo $name;?></td>
+            <td><?php echo $value;?></td>
+            </tr>
 
-        <?php endforeach; ?>
+            <?php endforeach; ?>
 
-    </tbody>
-</table>
+        </tbody>
+    </table>
 
-<div style="display:none;">
-    <b>TODO: load add-on diagnostics here, via filter</b>
+    <div style="display:none;">
+        <b>TODO: load add-on diagnostics here, via filter</b>
 
-    ie
+        ie
 
-    <p>PHP DOMDocument library available</p>
-    <code>        $view['domDocumentAvailable'] = class_exists( 'DOMDocument' );</code>
-    <h2 class="title">You're missing a required PHP library (DOMDocument)</h2>
-    <p> This is a library that is used to parse the HTML documents when WP2Static crawls your site. It's usually an easy fix to get this working. You can try Googling "DOMDocument missing", along with the name of the environment you are using to run your WordPress site. This may be something like DigitalOcean, GoDaddy or LAMP, MAMP, WAMP for your webserver on your local computer. If you're still having trouble, the developer of this plugin is easger to help you get up and running. Please ask for help on our <a href="https://forum.wp2static.com">forum</a>.</p>
+        <p>PHP DOMDocument library available</p>
+        <code>        $view['domDocumentAvailable'] = class_exists( 'DOMDocument' );</code>
+        <h2 class="title">You're missing a required PHP library (DOMDocument)</h2>
+        <p> This is a library that is used to parse the HTML documents when WP2Static crawls your site. It's usually an easy fix to get this working. You can try Googling "DOMDocument missing", along with the name of the environment you are using to run your WordPress site. This may be something like DigitalOcean, GoDaddy or LAMP, MAMP, WAMP for your webserver on your local computer. If you're still having trouble, the developer of this plugin is easger to help you get up and running. Please ask for help on our <a href="https://forum.wp2static.com">forum</a>.</p>
+    </div>
 </div>

--- a/views/jobs-page.php
+++ b/views/jobs-page.php
@@ -1,234 +1,236 @@
-<form
-    name="wp2static-job-options"
-    method="POST"
-    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+<div class="wrap">
+    <form
+        name="wp2static-job-options"
+        method="POST"
+        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
 
-<br>
+    <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <td style="width:33%;">
-                Events to queue new jobs
-            </td>
-            <td>
-                &nbsp;
-            </td>
-            <td>
-                Enabled?
-            </td>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td style="width:33%;">
-                <label
-                    for="<?php echo $view['jobOptions']['queueJobOnPostSave']->name; ?>"
-                /><b><?php echo $view['jobOptions']['queueJobOnPostSave']->label; ?></b></label>
-            </td>
-            <td>
-                <?php echo $view['jobOptions']['queueJobOnPostSave']->description; ?>
-            </td>
-            <td>
-                <input
-                    type="checkbox"
-                    id="<?php echo $view['jobOptions']['queueJobOnPostSave']->name; ?>"
-                    name="<?php echo $view['jobOptions']['queueJobOnPostSave']->name; ?>"
-                    value="1"
-                    <?php echo (int) $view['jobOptions']['queueJobOnPostSave']->value === 1 ? 'checked' : ''; ?>
-                />
-            </td>
-        </tr>
-        <tr>
-            <td style="width:33%;">
-                <label
-                    for="<?php echo $view['jobOptions']['queueJobOnPostDelete']->name; ?>"
-                /><b><?php echo $view['jobOptions']['queueJobOnPostDelete']->label; ?></b></label>
-            </td>
-            <td>
-                <?php echo $view['jobOptions']['queueJobOnPostDelete']->description; ?>
-            </td>
-            <td>
-                <input
-                    type="checkbox"
-                    id="<?php echo $view['jobOptions']['queueJobOnPostDelete']->name; ?>"
-                    name="<?php echo $view['jobOptions']['queueJobOnPostDelete']->name; ?>"
-                    value="1"
-                    <?php echo (int) $view['jobOptions']['queueJobOnPostDelete']->value === 1 ? 'checked' : ''; ?>
-                />
-            </td>
-        </tr>
-    </tbody>
-</table>
+    <table class="widefat striped">
+        <thead>
+            <tr>
+                <td style="width:33%;">
+                    Events to queue new jobs
+                </td>
+                <td>
+                    &nbsp;
+                </td>
+                <td>
+                    Enabled?
+                </td>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td style="width:33%;">
+                    <label
+                        for="<?php echo $view['jobOptions']['queueJobOnPostSave']->name; ?>"
+                    /><b><?php echo $view['jobOptions']['queueJobOnPostSave']->label; ?></b></label>
+                </td>
+                <td>
+                    <?php echo $view['jobOptions']['queueJobOnPostSave']->description; ?>
+                </td>
+                <td>
+                    <input
+                        type="checkbox"
+                        id="<?php echo $view['jobOptions']['queueJobOnPostSave']->name; ?>"
+                        name="<?php echo $view['jobOptions']['queueJobOnPostSave']->name; ?>"
+                        value="1"
+                        <?php echo (int) $view['jobOptions']['queueJobOnPostSave']->value === 1 ? 'checked' : ''; ?>
+                    />
+                </td>
+            </tr>
+            <tr>
+                <td style="width:33%;">
+                    <label
+                        for="<?php echo $view['jobOptions']['queueJobOnPostDelete']->name; ?>"
+                    /><b><?php echo $view['jobOptions']['queueJobOnPostDelete']->label; ?></b></label>
+                </td>
+                <td>
+                    <?php echo $view['jobOptions']['queueJobOnPostDelete']->description; ?>
+                </td>
+                <td>
+                    <input
+                        type="checkbox"
+                        id="<?php echo $view['jobOptions']['queueJobOnPostDelete']->name; ?>"
+                        name="<?php echo $view['jobOptions']['queueJobOnPostDelete']->name; ?>"
+                        value="1"
+                        <?php echo (int) $view['jobOptions']['queueJobOnPostDelete']->value === 1 ? 'checked' : ''; ?>
+                    />
+                </td>
+            </tr>
+        </tbody>
+    </table>
 
 
-<h4>Jobs that will be added to queue</h4>
+    <h4>Jobs that will be added to queue</h4>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <td style="text-align:center;">
-                Detect URLs
-            </td>
-            <td style="text-align:center;">
-                Crawl Site
-            </td>
-            <td style="text-align:center;">
-                Post-process
-            </td>
-            <td style="text-align:center;">
-                Deploy
-            </td>
-        </tr>
-    </thead>
-    <tbody>
-        <tr style="text-align:center;">
-            <td>
-                <input
-                    type="checkbox"
-                    id="<?php echo $view['jobOptions']['autoJobQueueDetection']->name; ?>"
-                    name="<?php echo $view['jobOptions']['autoJobQueueDetection']->name; ?>"
-                    value="1"
-                    <?php echo (int) $view['jobOptions']['autoJobQueueDetection']->value === 1 ? 'checked' : ''; ?>
-                />
-            </td>
+    <table class="widefat striped">
+        <thead>
+            <tr>
+                <td style="text-align:center;">
+                    Detect URLs
+                </td>
+                <td style="text-align:center;">
+                    Crawl Site
+                </td>
+                <td style="text-align:center;">
+                    Post-process
+                </td>
+                <td style="text-align:center;">
+                    Deploy
+                </td>
+            </tr>
+        </thead>
+        <tbody>
+            <tr style="text-align:center;">
+                <td>
+                    <input
+                        type="checkbox"
+                        id="<?php echo $view['jobOptions']['autoJobQueueDetection']->name; ?>"
+                        name="<?php echo $view['jobOptions']['autoJobQueueDetection']->name; ?>"
+                        value="1"
+                        <?php echo (int) $view['jobOptions']['autoJobQueueDetection']->value === 1 ? 'checked' : ''; ?>
+                    />
+                </td>
 
-            <td>
-                <input
-                    type="checkbox"
-                    id="<?php echo $view['jobOptions']['autoJobQueueCrawling']->name; ?>"
-                    name="<?php echo $view['jobOptions']['autoJobQueueCrawling']->name; ?>"
-                    value="1"
-                    <?php echo (int) $view['jobOptions']['autoJobQueueCrawling']->value === 1 ? 'checked' : ''; ?>
-                />
-            </td>
+                <td>
+                    <input
+                        type="checkbox"
+                        id="<?php echo $view['jobOptions']['autoJobQueueCrawling']->name; ?>"
+                        name="<?php echo $view['jobOptions']['autoJobQueueCrawling']->name; ?>"
+                        value="1"
+                        <?php echo (int) $view['jobOptions']['autoJobQueueCrawling']->value === 1 ? 'checked' : ''; ?>
+                    />
+                </td>
 
-            <td>
-                <input
-                    type="checkbox"
-                    id="<?php echo $view['jobOptions']['autoJobQueuePostProcessing']->name; ?>"
-                    name="<?php echo $view['jobOptions']['autoJobQueuePostProcessing']->name; ?>"
-                    value="1"
-                    <?php echo (int) $view['jobOptions']['autoJobQueuePostProcessing']->value === 1 ? 'checked' : ''; ?>
-                />
-            </td>
+                <td>
+                    <input
+                        type="checkbox"
+                        id="<?php echo $view['jobOptions']['autoJobQueuePostProcessing']->name; ?>"
+                        name="<?php echo $view['jobOptions']['autoJobQueuePostProcessing']->name; ?>"
+                        value="1"
+                        <?php echo (int) $view['jobOptions']['autoJobQueuePostProcessing']->value === 1 ? 'checked' : ''; ?>
+                    />
+                </td>
 
-            <td>
-                <input
-                    type="checkbox"
-                    id="<?php echo $view['jobOptions']['autoJobQueueDeployment']->name; ?>"
-                    name="<?php echo $view['jobOptions']['autoJobQueueDeployment']->name; ?>"
-                    value="1"
-                    <?php echo (int) $view['jobOptions']['autoJobQueueDeployment']->value === 1 ? 'checked' : ''; ?>
-                />
-            </td>
-        </tr>
-    </tbody>
-</table>
+                <td>
+                    <input
+                        type="checkbox"
+                        id="<?php echo $view['jobOptions']['autoJobQueueDeployment']->name; ?>"
+                        name="<?php echo $view['jobOptions']['autoJobQueueDeployment']->name; ?>"
+                        value="1"
+                        <?php echo (int) $view['jobOptions']['autoJobQueueDeployment']->value === 1 ? 'checked' : ''; ?>
+                    />
+                </td>
+            </tr>
+        </tbody>
+    </table>
 
-<br>
+    <br>
 
-<b>Process Queue Interval</b>
+    <b>Process Queue Interval</b>
 
-<br>
+    <br>
 
-<label
-    for=""
-/>WP-Cron will attempt to process the Job Queue at this interval:</label>
+    <label
+        for=""
+    />WP-Cron will attempt to process the Job Queue at this interval:</label>
 
-<select
-    id="<?php echo $view['jobOptions']['processQueueInterval']->name; ?>"
-    name="<?php echo $view['jobOptions']['processQueueInterval']->name; ?>"
-    value="<?php echo (int) $view['jobOptions']['processQueueInterval']->value; ?>"
-/>
-    <option
-        <?php echo (int) $view['jobOptions']['processQueueInterval']->value === 0 ? 'selected' : ''; ?>
-        value="0">disable (never)</option>
-    <option
-        <?php echo (int) $view['jobOptions']['processQueueInterval']->value === 1 ? 'selected' : ''; ?>
-        value="1">every minute</option>
-    <option
-        <?php echo (int) $view['jobOptions']['processQueueInterval']->value === 5 ? 'selected' : ''; ?>
-        value="5">every 5 minutes</option>
-    <option
-        <?php echo (int) $view['jobOptions']['processQueueInterval']->value === 10 ? 'selected' : ''; ?>
-        value="10">every 10 minutes</option>
-</select>
+    <select
+        id="<?php echo $view['jobOptions']['processQueueInterval']->name; ?>"
+        name="<?php echo $view['jobOptions']['processQueueInterval']->name; ?>"
+        value="<?php echo (int) $view['jobOptions']['processQueueInterval']->value; ?>"
+    />
+        <option
+            <?php echo (int) $view['jobOptions']['processQueueInterval']->value === 0 ? 'selected' : ''; ?>
+            value="0">disable (never)</option>
+        <option
+            <?php echo (int) $view['jobOptions']['processQueueInterval']->value === 1 ? 'selected' : ''; ?>
+            value="1">every minute</option>
+        <option
+            <?php echo (int) $view['jobOptions']['processQueueInterval']->value === 5 ? 'selected' : ''; ?>
+            value="5">every 5 minutes</option>
+        <option
+            <?php echo (int) $view['jobOptions']['processQueueInterval']->value === 10 ? 'selected' : ''; ?>
+            value="10">every 10 minutes</option>
+    </select>
 
-<p><i>If WP-Cron is not expected to be triggered by site visitors, you can also call `wp-cron.php` directly, run the WP-CLI command `wp wp2static process_queue` or call the hook `wp2static_process_queue` from within your own theme or plugin.</i></p>
+    <p><i>If WP-Cron is not expected to be triggered by site visitors, you can also call `wp-cron.php` directly, run the WP-CLI command `wp wp2static process_queue` or call the hook `wp2static_process_queue` from within your own theme or plugin.</i></p>
 
-    <button class="button btn-primary">Save Job Automation Settings</button>
+        <button class="button btn-primary">Save Job Automation Settings</button>
+        <?php wp_nonce_field( $view['nonce_action'] ); ?>
+        <input name="action" type="hidden" value="wp2static_ui_save_job_options" />
+    </form>
+
+    <br>
+    <form
+        name="wp2static-manually-enqueue-jobs"
+        method="POST"
+        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+
+        <?php wp_nonce_field( 'wp2static-manually-enqueue-jobs' ); ?>
+        <input name="action" type="hidden" value="wp2static_manually_enqueue_jobs" />
+
+        <button class="button">Manually Enqueue Jobs Now</button>
+    </form>
+
+    <hr>
+
+    <h3>Job Queue/History</h3>
+
+    <p><i><a href="<?php echo admin_url('admin.php?page=wp2static-jobs'); ?>">Refresh page</a> to see latest status</i><p>
+
+    <hr>
+
+    <table class="widefat striped">
+        <thead>
+            <tr>
+                <th>Date</th>
+                <th>Job</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($view['jobs'] as $job): ?>
+            <tr>
+                <td><?php echo $job->created_at; ?></td>
+                <td><?php echo $job->job_type; ?></td>
+                <td><?php echo $job->status; ?></td>
+            </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+
+    <br>
+
+    <form
+        name="wp2static-delete-jobs-queue"
+        method="POST"
+        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+
     <?php wp_nonce_field( $view['nonce_action'] ); ?>
-    <input name="action" type="hidden" value="wp2static_ui_save_job_options" />
-</form>
+    <input name="action" type="hidden" value="wp2static_delete_jobs_queue" />
 
-<br>
-<form
-    name="wp2static-manually-enqueue-jobs"
-    method="POST"
-    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+    <button class="wp2static-button button btn-danger">Delete all Jobs from Queue</button>
 
-    <?php wp_nonce_field( 'wp2static-manually-enqueue-jobs' ); ?>
-    <input name="action" type="hidden" value="wp2static_manually_enqueue_jobs" />
+    </form>
 
-    <button class="button">Manually Enqueue Jobs Now</button>
-</form>
+    <!-- TODO: consider manual queue processing, needs further testing, unstable execution so far
 
-<hr>
+    <br>
 
-<h3>Job Queue/History</h3>
+    <form
+        name="wp2static-process-jobs-queue"
+        method="POST"
+        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
 
-<p><i><a href="<?php echo admin_url('admin.php?page=wp2static-jobs'); ?>">Refresh page</a> to see latest status</i><p>
+    <?php wp_nonce_field( $view['nonce_action'] ); ?>
+    <input name="action" type="hidden" value="wp2static_process_jobs_queue" />
 
-<hr>
+    <button class="wp2static-button button btn-danger">Manually process Job Queue</button>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>Date</th>
-            <th>Job</th>
-            <th>Status</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php foreach ($view['jobs'] as $job): ?>
-        <tr>
-            <td><?php echo $job->created_at; ?></td>
-            <td><?php echo $job->job_type; ?></td>
-            <td><?php echo $job->status; ?></td>
-        </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
-
-<br>
-
-<form
-    name="wp2static-delete-jobs-queue"
-    method="POST"
-    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
-
-<?php wp_nonce_field( $view['nonce_action'] ); ?>
-<input name="action" type="hidden" value="wp2static_delete_jobs_queue" />
-
-<button class="wp2static-button button btn-danger">Delete all Jobs from Queue</button>
-
-</form>
-
-<!-- TODO: consider manual queue processing, needs further testing, unstable execution so far
-
-<br>
-
-<form
-    name="wp2static-process-jobs-queue"
-    method="POST"
-    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
-
-<?php wp_nonce_field( $view['nonce_action'] ); ?>
-<input name="action" type="hidden" value="wp2static_process_jobs_queue" />
-
-<button class="wp2static-button button btn-danger">Manually process Job Queue</button>
-
-</form>
+    </form>
 
 -->
+</div>

--- a/views/logs-page.php
+++ b/views/logs-page.php
@@ -1,41 +1,43 @@
-<br>
+<div class="wrap">
+    <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>When</th>
-            <th>What</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php if ( ! $view['logs'] ) : ?>
+    <table class="widefat striped">
+        <thead>
             <tr>
-                <td colspan="2">Logs are empty.</td>
+                <th>When</th>
+                <th>What</th>
             </tr>
-        <?php endif; ?>
+        </thead>
+        <tbody>
+            <?php if ( ! $view['logs'] ) : ?>
+                <tr>
+                    <td colspan="2">Logs are empty.</td>
+                </tr>
+            <?php endif; ?>
 
 
-        <?php foreach( $view['logs'] as $log ) : ?>
-            <tr>
-                <td><?php echo $log->time; ?></td>
-                <td><?php echo $log->log; ?></td>
-            </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
+            <?php foreach( $view['logs'] as $log ) : ?>
+                <tr>
+                    <td><?php echo $log->time; ?></td>
+                    <td><?php echo $log->log; ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
 
-<br> 
+    <br> 
 
-<?php if ( $view['logs'] ) : ?>
-    <form
-        name="wp2static-log-delete"
-        method="POST"
-        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+    <?php if ( $view['logs'] ) : ?>
+        <form
+            name="wp2static-log-delete"
+            method="POST"
+            action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
 
-    <?php wp_nonce_field( $view['nonce_action'] ); ?>
-    <input name="action" type="hidden" value="wp2static_log_delete" />
+        <?php wp_nonce_field( $view['nonce_action'] ); ?>
+        <input name="action" type="hidden" value="wp2static_log_delete" />
 
-    <button class="wp2static-button button btn-danger">Delete Log</button>
+        <button class="wp2static-button button btn-danger">Delete Log</button>
 
-    </form>
-<?php endif; ?>
+        </form>
+    <?php endif; ?>
+</div>

--- a/views/options-page.php
+++ b/views/options-page.php
@@ -14,234 +14,236 @@ function displayCheckbox($a = null, $b = null, $c = null) {
 }
 
 ?>
-<form
-    name="wp2static-ui-options"
-    method="POST"
-    action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
+<div class="wrap">
+    <form
+        name="wp2static-ui-options"
+        method="POST"
+        action="<?php echo esc_url( admin_url('admin-post.php') ); ?>">
 
-<h2>Detection Options</h2>
+    <h2>Detection Options</h2>
 
-<h4>Control Detected URLs</h4>
+    <h4>Control Detected URLs</h4>
 
-<p>WP2Static will crawl these WordPress URLs to generate a static site.</p>
+    <p>WP2Static will crawl these WordPress URLs to generate a static site.</p>
 
-<table class="striped widefat">
-    <thead>
-        <tr>
-            <th style="width:50%;">URL Type</th>
-            <th>Include in detection</th>
-        </tr>
-    </thead>
-    <tbody>
-
-    <tr>
-        <td>
-            <label
-                for="<?php echo $view['coreOptions']['detectCustomPostTypes']->name; ?>"
-            ><?php echo $view['coreOptions']['detectCustomPostTypes']->label; ?></label>
-        </td>
-        <td>
-            <input
-                id="<?php echo $view['coreOptions']['detectCustomPostTypes']->name; ?>"
-                name="<?php echo $view['coreOptions']['detectCustomPostTypes']->name; ?>"
-                value="1"
-                type="checkbox"
-                <?php echo (int) $view['coreOptions']['detectCustomPostTypes']->value === 1 ? 'checked' : ''; ?>
-            />
-        </td>
-    </tr>
-
-    <tr>
-        <td>
-            <label
-                for="<?php echo $view['coreOptions']['detectPages']->name; ?>"
-            ><?php echo $view['coreOptions']['detectPages']->label; ?></label>
-        </td>
-        <td>
-            <input
-                id="<?php echo $view['coreOptions']['detectPages']->name; ?>"
-                name="<?php echo $view['coreOptions']['detectPages']->name; ?>"
-                value="1"
-                type="checkbox"
-                <?php echo (int) $view['coreOptions']['detectPages']->value === 1 ? 'checked' : ''; ?>
-            />
-        </td>
-    </tr>
-
-    <tr>
-        <td>
-            <label
-                for="<?php echo $view['coreOptions']['detectPosts']->name; ?>"
-            ><?php echo $view['coreOptions']['detectPosts']->label; ?></label>
-        </td>
-        <td>
-            <input
-                id="<?php echo $view['coreOptions']['detectPosts']->name; ?>"
-                name="<?php echo $view['coreOptions']['detectPosts']->name; ?>"
-                value="1"
-                type="checkbox"
-                <?php echo (int) $view['coreOptions']['detectPosts']->value === 1 ? 'checked' : ''; ?>
-            />
-        </td>
-    </tr>
-
-    <tr>
-        <td>
-            <label
-                for="<?php echo $view['coreOptions']['detectUploads']->name; ?>"
-            ><?php echo $view['coreOptions']['detectUploads']->label; ?></label>
-        </td>
-        <td>
-            <input
-                id="<?php echo $view['coreOptions']['detectUploads']->name; ?>"
-                name="<?php echo $view['coreOptions']['detectUploads']->name; ?>"
-                value="1"
-                type="checkbox"
-                <?php echo (int) $view['coreOptions']['detectUploads']->value === 1 ? 'checked' : ''; ?>
-            />
-        </td>
-    </tr>
-
-    </tbody>
-</table>
-
-<h2>Crawling Options</h2>
-
-<table class="widefat striped">
-    <tbody>
-
-        <tr>
-            <td style="width:50%;">
-                <label
-                    for="<?php echo $view['coreOptions']['basicAuthUser']->name; ?>"
-                ><?php echo $view['coreOptions']['basicAuthUser']->label; ?></label>
-            </td>
-            <td>
-                <input
-                    id="<?php echo $view['coreOptions']['basicAuthUser']->name; ?>"
-                    name="<?php echo $view['coreOptions']['basicAuthUser']->name; ?>"
-                    type="text"
-                    value="<?php echo $view['coreOptions']['basicAuthUser']->value !== '' ? $view['coreOptions']['basicAuthUser']->value : ''; ?>"
-                />
-            </td>
-        </tr>
-
-        <tr>
-            <td style="width:50%;">
-                <label
-                    for="<?php echo $view['coreOptions']['basicAuthPassword']->name; ?>"
-                ><?php echo $view['coreOptions']['basicAuthPassword']->label; ?></label>
-            </td>
-            <td>
-                <input
-                    id="<?php echo $view['coreOptions']['basicAuthPassword']->name; ?>"
-                    name="<?php echo $view['coreOptions']['basicAuthPassword']->name; ?>"
-                    type="password"
-                    value="<?php echo $view['coreOptions']['basicAuthPassword']->value !== '' ? $view['coreOptions']['basicAuthPassword']->value : ''; ?>"
-                />
-            </td>
-        </tr>
+    <table class="striped widefat">
+        <thead>
+            <tr>
+                <th style="width:50%;">URL Type</th>
+                <th>Include in detection</th>
+            </tr>
+        </thead>
+        <tbody>
 
         <tr>
             <td>
                 <label
-                    for="<?php echo $view['coreOptions']['useCrawlCaching']->name; ?>"
-                ><?php echo $view['coreOptions']['useCrawlCaching']->label; ?></label>
+                    for="<?php echo $view['coreOptions']['detectCustomPostTypes']->name; ?>"
+                ><?php echo $view['coreOptions']['detectCustomPostTypes']->label; ?></label>
             </td>
             <td>
                 <input
-                    id="<?php echo $view['coreOptions']['useCrawlCaching']->name; ?>"
-                    name="<?php echo $view['coreOptions']['useCrawlCaching']->name; ?>"
+                    id="<?php echo $view['coreOptions']['detectCustomPostTypes']->name; ?>"
+                    name="<?php echo $view['coreOptions']['detectCustomPostTypes']->name; ?>"
                     value="1"
                     type="checkbox"
-                    <?php echo (int) $view['coreOptions']['useCrawlCaching']->value === 1 ? 'checked' : ''; ?>
+                    <?php echo (int) $view['coreOptions']['detectCustomPostTypes']->value === 1 ? 'checked' : ''; ?>
                 />
             </td>
         </tr>
 
-    </tbody>
-</table>
-
-<h2>Post-processing Options</h2>
-
-<table class="widefat striped">
-    <tbody>
         <tr>
-            <td style="width:50%;">
+            <td>
                 <label
-                    for="<?php echo $view['coreOptions']['deploymentURL']->name; ?>"
-                ><?php echo $view['coreOptions']['deploymentURL']->label; ?></label>
+                    for="<?php echo $view['coreOptions']['detectPages']->name; ?>"
+                ><?php echo $view['coreOptions']['detectPages']->label; ?></label>
             </td>
             <td>
                 <input
-                    id="<?php echo $view['coreOptions']['deploymentURL']->name; ?>"
-                    name="<?php echo $view['coreOptions']['deploymentURL']->name; ?>"
-                    type="text"
-                    value="<?php echo $view['coreOptions']['deploymentURL']->value !== '' ? $view['coreOptions']['deploymentURL']->value : ''; ?>"
+                    id="<?php echo $view['coreOptions']['detectPages']->name; ?>"
+                    name="<?php echo $view['coreOptions']['detectPages']->name; ?>"
+                    value="1"
+                    type="checkbox"
+                    <?php echo (int) $view['coreOptions']['detectPages']->value === 1 ? 'checked' : ''; ?>
                 />
             </td>
         </tr>
-    </tbody>
-</table>
 
-<h2>Deployment Options</h2>
-
-<table class="widefat striped">
-    <tbody>
         <tr>
-            <td style="width:50%;">
+            <td>
                 <label
-                    for="<?php echo $view['coreOptions']['completionEmail']->name; ?>"
-                ><?php echo $view['coreOptions']['completionEmail']->label; ?></label>
+                    for="<?php echo $view['coreOptions']['detectPosts']->name; ?>"
+                ><?php echo $view['coreOptions']['detectPosts']->label; ?></label>
             </td>
             <td>
                 <input
-                    style="width:100%;"
-                    type="email"
-                    id="<?php echo $view['coreOptions']['completionEmail']->name; ?>"
-                    name="<?php echo $view['coreOptions']['completionEmail']->name; ?>"
-                    value="<?php echo $view['coreOptions']['completionEmail']->value !== '' ? $view['coreOptions']['completionEmail']->value : ''; ?>"
+                    id="<?php echo $view['coreOptions']['detectPosts']->name; ?>"
+                    name="<?php echo $view['coreOptions']['detectPosts']->name; ?>"
+                    value="1"
+                    type="checkbox"
+                    <?php echo (int) $view['coreOptions']['detectPosts']->value === 1 ? 'checked' : ''; ?>
                 />
             </td>
         </tr>
+
         <tr>
-            <td style="width:50%;">
+            <td>
                 <label
-                    for="<?php echo $view['coreOptions']['completionWebhook']->name; ?>"
-                ><?php echo $view['coreOptions']['completionWebhook']->label; ?></label>
+                    for="<?php echo $view['coreOptions']['detectUploads']->name; ?>"
+                ><?php echo $view['coreOptions']['detectUploads']->label; ?></label>
             </td>
             <td>
                 <input
-                    style="width:80%;"
-                    type="url"
-                    id="completionWebhook"
-                    name="completionWebhook"
-                    value="<?php echo $view['coreOptions']['completionWebhook']->value !== '' ? $view['coreOptions']['completionWebhook']->value : ''; ?>"
+                    id="<?php echo $view['coreOptions']['detectUploads']->name; ?>"
+                    name="<?php echo $view['coreOptions']['detectUploads']->name; ?>"
+                    value="1"
+                    type="checkbox"
+                    <?php echo (int) $view['coreOptions']['detectUploads']->value === 1 ? 'checked' : ''; ?>
                 />
-
-                <select
-                    id="<?php echo $view['coreOptions']['completionWebhookMethod']->name; ?>"
-                    name="<?php echo $view['coreOptions']['completionWebhookMethod']->name; ?>"
-                    >
-                    <option
-                        value="POST"
-                        <?php echo $view['coreOptions']['completionWebhookMethod']->value === 'POST' ? 'selected' : ''; ?>
-                        >POST</option>
-                    <option
-                        value="GET"
-                        <?php echo $view['coreOptions']['completionWebhookMethod']->value === 'GET' ? 'selected' : ''; ?>
-                        >GET</option>
-                </select>
             </td>
         </tr>
-    </tbody>
-</table>
 
-<br>
+        </tbody>
+    </table>
 
-<?php wp_nonce_field( $view['nonce_action'] ); ?>
-<input name="action" type="hidden" value="wp2static_ui_save_options" />
+    <h2>Crawling Options</h2>
 
-<button class="button btn-primary" type="submit">Save options</button>
+    <table class="widefat striped">
+        <tbody>
 
-</form>
+            <tr>
+                <td style="width:50%;">
+                    <label
+                        for="<?php echo $view['coreOptions']['basicAuthUser']->name; ?>"
+                    ><?php echo $view['coreOptions']['basicAuthUser']->label; ?></label>
+                </td>
+                <td>
+                    <input
+                        id="<?php echo $view['coreOptions']['basicAuthUser']->name; ?>"
+                        name="<?php echo $view['coreOptions']['basicAuthUser']->name; ?>"
+                        type="text"
+                        value="<?php echo $view['coreOptions']['basicAuthUser']->value !== '' ? $view['coreOptions']['basicAuthUser']->value : ''; ?>"
+                    />
+                </td>
+            </tr>
+
+            <tr>
+                <td style="width:50%;">
+                    <label
+                        for="<?php echo $view['coreOptions']['basicAuthPassword']->name; ?>"
+                    ><?php echo $view['coreOptions']['basicAuthPassword']->label; ?></label>
+                </td>
+                <td>
+                    <input
+                        id="<?php echo $view['coreOptions']['basicAuthPassword']->name; ?>"
+                        name="<?php echo $view['coreOptions']['basicAuthPassword']->name; ?>"
+                        type="password"
+                        value="<?php echo $view['coreOptions']['basicAuthPassword']->value !== '' ? $view['coreOptions']['basicAuthPassword']->value : ''; ?>"
+                    />
+                </td>
+            </tr>
+
+            <tr>
+                <td>
+                    <label
+                        for="<?php echo $view['coreOptions']['useCrawlCaching']->name; ?>"
+                    ><?php echo $view['coreOptions']['useCrawlCaching']->label; ?></label>
+                </td>
+                <td>
+                    <input
+                        id="<?php echo $view['coreOptions']['useCrawlCaching']->name; ?>"
+                        name="<?php echo $view['coreOptions']['useCrawlCaching']->name; ?>"
+                        value="1"
+                        type="checkbox"
+                        <?php echo (int) $view['coreOptions']['useCrawlCaching']->value === 1 ? 'checked' : ''; ?>
+                    />
+                </td>
+            </tr>
+
+        </tbody>
+    </table>
+
+    <h2>Post-processing Options</h2>
+
+    <table class="widefat striped">
+        <tbody>
+            <tr>
+                <td style="width:50%;">
+                    <label
+                        for="<?php echo $view['coreOptions']['deploymentURL']->name; ?>"
+                    ><?php echo $view['coreOptions']['deploymentURL']->label; ?></label>
+                </td>
+                <td>
+                    <input
+                        id="<?php echo $view['coreOptions']['deploymentURL']->name; ?>"
+                        name="<?php echo $view['coreOptions']['deploymentURL']->name; ?>"
+                        type="text"
+                        value="<?php echo $view['coreOptions']['deploymentURL']->value !== '' ? $view['coreOptions']['deploymentURL']->value : ''; ?>"
+                    />
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h2>Deployment Options</h2>
+
+    <table class="widefat striped">
+        <tbody>
+            <tr>
+                <td style="width:50%;">
+                    <label
+                        for="<?php echo $view['coreOptions']['completionEmail']->name; ?>"
+                    ><?php echo $view['coreOptions']['completionEmail']->label; ?></label>
+                </td>
+                <td>
+                    <input
+                        style="width:100%;"
+                        type="email"
+                        id="<?php echo $view['coreOptions']['completionEmail']->name; ?>"
+                        name="<?php echo $view['coreOptions']['completionEmail']->name; ?>"
+                        value="<?php echo $view['coreOptions']['completionEmail']->value !== '' ? $view['coreOptions']['completionEmail']->value : ''; ?>"
+                    />
+                </td>
+            </tr>
+            <tr>
+                <td style="width:50%;">
+                    <label
+                        for="<?php echo $view['coreOptions']['completionWebhook']->name; ?>"
+                    ><?php echo $view['coreOptions']['completionWebhook']->label; ?></label>
+                </td>
+                <td>
+                    <input
+                        style="width:80%;"
+                        type="url"
+                        id="completionWebhook"
+                        name="completionWebhook"
+                        value="<?php echo $view['coreOptions']['completionWebhook']->value !== '' ? $view['coreOptions']['completionWebhook']->value : ''; ?>"
+                    />
+
+                    <select
+                        id="<?php echo $view['coreOptions']['completionWebhookMethod']->name; ?>"
+                        name="<?php echo $view['coreOptions']['completionWebhookMethod']->name; ?>"
+                        >
+                        <option
+                            value="POST"
+                            <?php echo $view['coreOptions']['completionWebhookMethod']->value === 'POST' ? 'selected' : ''; ?>
+                            >POST</option>
+                        <option
+                            value="GET"
+                            <?php echo $view['coreOptions']['completionWebhookMethod']->value === 'GET' ? 'selected' : ''; ?>
+                            >GET</option>
+                    </select>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <br>
+
+    <?php wp_nonce_field( $view['nonce_action'] ); ?>
+    <input name="action" type="hidden" value="wp2static_ui_save_options" />
+
+    <button class="button btn-primary" type="submit">Save options</button>
+
+    </form>
+</div>

--- a/views/post-processed-site-paths-page.php
+++ b/views/post-processed-site-paths-page.php
@@ -1,24 +1,25 @@
-<br>
+<div class="wrap">
+    <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>Paths in Post-processed Static Site</th>
-        </tr>
-    </thead>
-    <tbody>
-
-        <?php if ( ! $view['paths'] ) : ?>
+    <table class="widefat striped">
+        <thead>
             <tr>
-                <td>Post-processed site directory is empty.</td>
+                <th>Paths in Post-processed Static Site</th>
             </tr>
-        <?php endif; ?>
+        </thead>
+        <tbody>
 
-        <?php foreach( $view['paths'] as $path ) : ?>
-            <tr>
-                <td><?php echo $path; ?></td>
-            </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
+            <?php if ( ! $view['paths'] ) : ?>
+                <tr>
+                    <td>Post-processed site directory is empty.</td>
+                </tr>
+            <?php endif; ?>
 
+            <?php foreach( $view['paths'] as $path ) : ?>
+                <tr>
+                    <td><?php echo $path; ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>

--- a/views/run-page.php
+++ b/views/run-page.php
@@ -61,18 +61,20 @@ More information of the error may be logged in your browser's console.`);
 });
 </script>
 
-<br>
+<div class="wrap">
+    <br>
 
-<button class="button button-primary" id="wp2static-run">Generate static site</button>
+    <button class="button button-primary" id="wp2static-run">Generate static site</button>
 
-<div id="wp2static-spinner" class="spinner" style="padding:2px;float:none;"></div>
+    <div id="wp2static-spinner" class="spinner" style="padding:2px;float:none;"></div>
 
-<br>
-<br>
+    <br>
+    <br>
 
-<button class="button" id="wp2static-poll-logs">Refresh logs</button>
-<br>
-<br>
-<textarea id="wp2static-run-log" rows=30 style="width:99%;">
-Logs will appear here on completion or click "Refresh logs" to check progress
-</textarea>
+    <button class="button" id="wp2static-poll-logs">Refresh logs</button>
+    <br>
+    <br>
+    <textarea id="wp2static-run-log" rows=30 style="width:99%;">
+    Logs will appear here on completion or click "Refresh logs" to check progress
+    </textarea>
+</div>

--- a/views/static-site-paths-page.php
+++ b/views/static-site-paths-page.php
@@ -1,24 +1,25 @@
-<br>
+<div class="wrap">
+    <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>Paths in Generated Static Site</th>
-        </tr>
-    </thead>
-    <tbody>
-
-        <?php if ( ! $view['paths'] ) : ?>
+    <table class="widefat striped">
+        <thead>
             <tr>
-                <td>Generated static site directory is empty.</td>
+                <th>Paths in Generated Static Site</th>
             </tr>
-        <?php endif; ?>
+        </thead>
+        <tbody>
 
-        <?php foreach( $view['paths'] as $path ) : ?>
-            <tr>
-                <td><?php echo $path; ?></td>
-            </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
+            <?php if ( ! $view['paths'] ) : ?>
+                <tr>
+                    <td>Generated static site directory is empty.</td>
+                </tr>
+            <?php endif; ?>
 
+            <?php foreach( $view['paths'] as $path ) : ?>
+                <tr>
+                    <td><?php echo $path; ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
Noticed your pages were missing the `wrap` div tag resulting in tables hitting the right edge of the page. I added these missing tags to each page so the styling is consistent with the rest of WP admin.

Before:
![Screen Shot 2020-08-11 at 10 54 10 am](https://user-images.githubusercontent.com/334808/89845460-e081de80-dbc1-11ea-9d3e-0c4d65d53696.png)

After:
![Screen Shot 2020-08-11 at 10 54 51 am](https://user-images.githubusercontent.com/334808/89845467-e4adfc00-dbc1-11ea-8f95-df63bdfd2190.png)
