### PR TITLE
Fix linting errors presumably causing Circle CI fail following commit 613f650

### DIFF
--- a/src/FilesHelper.php
+++ b/src/FilesHelper.php
@@ -166,9 +166,9 @@ class FilesHelper {
                 $file_extensions_to_ignore
             );
 
-        preg_replace( $file_extension_regex_patterns, '', $file_name, -1,  $file_extension_matches);
+        preg_replace( $file_extension_regex_patterns, '', $file_name, -1, $file_extension_matches );
 
-        if (  $filename_matches + $file_extension_matches > 0 ) {
+        if ( $filename_matches + $file_extension_matches > 0 ) {
             return false;
         }
 


### PR DESCRIPTION
Apologies, I neglected to run ```composer run-script test``` prior to my last pull request ... There were some extra spaces lying about.

Running  ```composer run-script phpunit``` and ```composer run-script coverage``` rely on class ```WP_Mock``` which is no longer in the vendor dependencies, so I assume those scripts aren't currently in use.

Let me know if I should be doing anything else for QC though prior to pull requests.