### PR TITLE
use getCol to save unnecessary data manipulation

### DIFF
--- a/src/CrawlCache.php
+++ b/src/CrawlCache.php
@@ -36,11 +36,7 @@ class CrawlCache {
 
         $table_name = $wpdb->prefix . 'wp2static_crawl_cache';
 
-        $rows = $wpdb->get_results( "SELECT hashed_url FROM $table_name" );
-
-        foreach ( $rows as $row ) {
-            $urls[] = $row->hashed_url;
-        }
+        $urls = $wpdb->get_col( "SELECT hashed_url FROM $table_name" );
 
         return $urls;
     }

--- a/src/CrawlQueue.php
+++ b/src/CrawlQueue.php
@@ -59,11 +59,7 @@ class CrawlQueue {
 
         $table_name = $wpdb->prefix . 'wp2static_urls';
 
-        $rows = $wpdb->get_results( "SELECT url FROM $table_name ORDER by url ASC" );
-
-        foreach ( $rows as $row ) {
-            $urls[] = $row->url;
-        }
+        $urls = $wpdb->get_col( "SELECT url FROM $table_name ORDER by url ASC" );
 
         return $urls;
     }

--- a/src/DeployCache.php
+++ b/src/DeployCache.php
@@ -174,15 +174,9 @@ class DeployCache {
 
         $table_name = $wpdb->prefix . 'wp2static_deploy_cache';
 
-        $sql = "SELECT path FROM $table_name WHERE namespace = %s";
+        $sql = "SELECT path FROM $table_name WHERE namespace = %s ORDER BY path";
         $sql = $wpdb->prepare( $sql, $namespace );
-        $rows = $wpdb->get_results( $sql );
-
-        foreach ( $rows as $row ) {
-            $urls[] = $row->path;
-        }
-
-        sort( $urls );
+        $urls = $wpdb->get_col( $sql );
 
         return $urls;
     }


### PR DESCRIPTION
WPDB has a [built in method](https://codex.wordpress.org/Class_Reference/wpdb#SELECT_a_Column) to handle what you're trying to do here.