### PR TITLE
Add pagination, search and actions to crawl queue page

### DIFF
--- a/src/CrawlQueue.php
+++ b/src/CrawlQueue.php
@@ -64,9 +64,35 @@ class CrawlQueue {
 
         $table_name = $wpdb->prefix . 'wp2static_urls';
 
-        $urls = $wpdb->get_col( "SELECT url FROM $table_name ORDER by url ASC" );
+        $rows = $wpdb->get_results( "SELECT id, url FROM $table_name ORDER by url ASC" );
+
+        foreach ( $rows as $row ) {
+            $urls[ $row->id ] = $row->url;
+        }
 
         return $urls;
+    }
+
+    /**
+     * Remove multiple URLs at once
+     *
+     * @param array<string> $ids
+     * @return void
+     */
+    public static function rmUrlsById( array $ids ) : void {
+        global $wpdb;
+
+        $ids = array_map(
+            function ( string $id ) {
+                return absint( $id );
+            },
+            $ids
+        );
+        $ids = implode( ',', array_map( 'absint', $ids ) );
+
+        $table_name = $wpdb->prefix . 'wp2static_urls';
+
+        $wpdb->query( "DELETE FROM $table_name WHERE ID IN($ids)" );
     }
 
     /**

--- a/src/URLHelper.php
+++ b/src/URLHelper.php
@@ -6,6 +6,48 @@ use Exception;
 
 class URLHelper {
     /*
+     * Returns the current full URL including querystring
+     *
+     * @return string
+     */
+    public static function getCurrent() : string {
+        $scheme = $_SERVER['SERVER_PORT'] == 80 ? 'http' : 'https';
+        return $scheme . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+    }
+
+    /**
+     * Returns a URL with given querystring modifications
+     *
+     * @param array<string> $changes  List of querystring params to set
+     * @param string $url             A complete URL. Leave empty to use current URL
+     * @return string                 The new URL
+     */
+    public static function modifyUrl( array $changes, string $url = '' ) : string {
+        // If $url wasn't passed in, use the current url
+        if ( $url === '' ) {
+            $url = self::getCurrent();
+        }
+
+        // Parse the url into pieces
+        $url_array = (array) parse_url( $url );
+
+        // The original URL had a query string, modify it.
+        if ( array_key_exists( 'query', $url_array ) ) {
+            parse_str( $url_array['query'], $query_array );
+            foreach ( $changes as $key => $value ) {
+                $query_array[ $key ] = $value;
+            }
+        } else {
+            // The original URL didn't have a query string, add it.
+            $query_array = $changes;
+        }
+
+        return $url_array['scheme'] . '://' .
+            $url_array['host'] . $url_array['path'] . '?' .
+            http_build_query( $query_array );
+    }
+
+    /*
      * Takes either an http or https URL and returns a // protocol-relative URL
      *
      * @param string URL either http or https

--- a/src/URLHelper.php
+++ b/src/URLHelper.php
@@ -13,12 +13,9 @@ class URLHelper {
     public static function getCurrent() : string {
         $scheme = $_SERVER['HTTPS'] === 'on' ? 'http' : 'https';
         $url = $scheme . '://' . $_SERVER['HTTP_HOST'];
-        
+
         // Only include port number if needed
-        if (
-            $_SERVER['SERVER_PORT'] == '80' && $scheme != 'http' ||
-            $_SERVER['SERVER_PORT'] == '443' && $scheme != 'https'
-        ) {
+        if ( ! in_array( $_SERVER['SERVER_PORT'], [ 80, 443 ] ) ) {
             $url .= ':' . $_SERVER['SERVER_PORT'];
         }
 

--- a/src/URLHelper.php
+++ b/src/URLHelper.php
@@ -11,8 +11,20 @@ class URLHelper {
      * @return string
      */
     public static function getCurrent() : string {
-        $scheme = $_SERVER['SERVER_PORT'] == 80 ? 'http' : 'https';
-        return $scheme . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        $scheme = $_SERVER['HTTPS'] === 'on' ? 'http' : 'https';
+        $url = $scheme . '://' . $_SERVER['HTTP_HOST'];
+        
+        // Only include port number if needed
+        if (
+            $_SERVER['SERVER_PORT'] == '80' && $scheme != 'http' ||
+            $_SERVER['SERVER_PORT'] == '443' && $scheme != 'https'
+        ) {
+            $url .= ':' . $_SERVER['SERVER_PORT'];
+        }
+
+        $url .= $_SERVER['REQUEST_URI'];
+
+        return $url;
     }
 
     /**

--- a/views/crawl-queue-page.php
+++ b/views/crawl-queue-page.php
@@ -1,88 +1,89 @@
 <div class="wrap">
     <br>
 
-<form id="posts-filter" method="GET">
-    <input type="hidden" name="page" value="<?php echo $_GET['page']; ?>" />
+    <form id="posts-filter" method="GET">
+        <input type="hidden" name="page" value="<?php echo $_GET['page']; ?>" />
 
-    <p class="search-box">
-        <label class="screen-reader-text" for="post-search-input">Search Crawl Queue URLs:</label>
-        <input type="search" id="post-search-input" name="s" value="<?php echo esc_attr( @$_GET['s'] ); ?>">
-        <input type="submit" id="search-submit" class="button" value="Search URLs">
-    </p>
+        <p class="search-box">
+            <label class="screen-reader-text" for="post-search-input">Search Crawl Queue URLs:</label>
+            <input type="search" id="post-search-input" name="s" value="<?php echo esc_attr( @$_GET['s'] ); ?>">
+            <input type="submit" id="search-submit" class="button" value="Search URLs">
+        </p>
 
-    <div class="tablenav top">
-        <div class="alignleft actions bulkactions">
-			<label for="bulk-action-selector-top" class="screen-reader-text">Select bulk action</label>
-            <select name="action" id="bulk-action-selector-top">
-                <option value="-1">Bulk Actions</option>
-                <option value="remove">Remove</option>
-            </select>
-            <input type="submit" id="doaction" class="button action" value="Apply">
-		</div>
-	
-        <h2 class="screen-reader-text">Crawl Queue list navigation</h2>
-        <div class="tablenav-pages">
-            <span class="displaying-num"><?php echo number_format($view['total_count']); ?> items</span>
-            <span class="pagination-links">
-                <?php if ($view['page'] === 1): ?>
-                    <span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
-                    <span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
-                <?php else: ?>
-                    <a class="first-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => 1]); ?>"><span class="screen-reader-text">First page</span><span aria-hidden="true">«</span></a>
-                    <a class="prev-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => $view['page'] - 1]); ?>"><span class="screen-reader-text">Previous page</span><span aria-hidden="true">‹</span></a>
-                <?php endif; ?>
-                <span class="paging-input">
-                    <label for="current-page-selector" class="screen-reader-text">Current Page</label>
-                    <input class="current-page" id="current-page-selector" type="text" name="paged" value="<?php echo $view['page']; ?>" size="3" aria-describedby="table-paging">
-                    <span class="tablenav-paging-text"> of 
-                        <span class="total-pages"><?php echo $view['pages']; ?></span>
+        <div class="tablenav top">
+            <div class="alignleft actions bulkactions">
+                <label for="bulk-action-selector-top" class="screen-reader-text">Select bulk action</label>
+                <select name="action" id="bulk-action-selector-top">
+                    <option value="-1">Bulk Actions</option>
+                    <option value="remove">Remove</option>
+                </select>
+                <input type="submit" id="doaction" class="button action" value="Apply">
+            </div>
+        
+            <h2 class="screen-reader-text">Crawl Queue list navigation</h2>
+            <div class="tablenav-pages">
+                <span class="displaying-num"><?php echo number_format($view['total_count']); ?> items</span>
+                <span class="pagination-links">
+                    <?php if ($view['page'] === 1): ?>
+                        <span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
+                        <span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
+                    <?php else: ?>
+                        <a class="first-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => 1]); ?>"><span class="screen-reader-text">First page</span><span aria-hidden="true">«</span></a>
+                        <a class="prev-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => $view['page'] - 1]); ?>"><span class="screen-reader-text">Previous page</span><span aria-hidden="true">‹</span></a>
+                    <?php endif; ?>
+                    <span class="paging-input">
+                        <label for="current-page-selector" class="screen-reader-text">Current Page</label>
+                        <input class="current-page" id="current-page-selector" type="text" name="paged" value="<?php echo $view['page']; ?>" size="3" aria-describedby="table-paging">
+                        <span class="tablenav-paging-text"> of 
+                            <span class="total-pages"><?php echo $view['pages']; ?></span>
+                        </span>
                     </span>
+                    <?php if ($view['page'] === $view['pages']): ?>
+                        <span class="tablenav-pages-navspan button disabled" aria-hidden="true">›</span>
+                        <span class="tablenav-pages-navspan button disabled" aria-hidden="true">»</span>
+                    <?php else: ?>
+                        <a class="next-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => $view['page'] + 1]); ?>"><span class="screen-reader-text">Next page</span><span aria-hidden="true">›</span></a>
+                        <a class="last-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => $view['pages']]); ?>"><span class="screen-reader-text">Last page</span><span aria-hidden="true">»</span></a>
+                    <?php endif; ?>
                 </span>
-                <?php if ($view['page'] === $view['pages']): ?>
-                    <span class="tablenav-pages-navspan button disabled" aria-hidden="true">›</span>
-                    <span class="tablenav-pages-navspan button disabled" aria-hidden="true">»</span>
-                <?php else: ?>
-                    <a class="next-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => $view['page'] + 1]); ?>"><span class="screen-reader-text">Next page</span><span aria-hidden="true">›</span></a>
-                    <a class="last-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => $view['pages']]); ?>"><span class="screen-reader-text">Last page</span><span aria-hidden="true">»</span></a>
-                <?php endif; ?>
-            </span>
+            </div>
+            <br class="clear">
         </div>
-		<br class="clear">
-    </div>
 
-    <table class="wp-list-table widefat striped">
-        <thead>
-            <tr>
-                <td id="cb" class="manage-column column-cb check-column">
-                    <label class="screen-reader-text" for="cb-select-all-1">Select All</label>
-                    <input id="cb-select-all-1" type="checkbox">
-                </td>
-                <th>URLs in Crawl Queue</th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php if ( ! $view['urls'] ) : ?>
+        <table class="wp-list-table widefat striped">
+            <thead>
                 <tr>
-                    <th>&nbsp;</th>
-                    <td>Crawl queue is empty.</td>
+                    <td id="cb" class="manage-column column-cb check-column">
+                        <label class="screen-reader-text" for="cb-select-all-1">Select All</label>
+                        <input id="cb-select-all-1" type="checkbox">
+                    </td>
+                    <th>URLs in Crawl Queue</th>
                 </tr>
-            <?php endif; ?>
+            </thead>
+            <tbody>
+                <?php if ( ! $view['urls'] ) : ?>
+                    <tr>
+                        <th>&nbsp;</th>
+                        <td>Crawl queue is empty.</td>
+                    </tr>
+                <?php endif; ?>
 
-            <?php foreach( $view['urls'] as $id => $url ) : ?>
-                <tr>
-                    <th scope="row" class="check-column">
-                        <label class="screen-reader-text" for="cb-select-<?php echo $id; ?>">
-                            Select <?php echo $url; ?>
-                        </label>
-                        <input id="cb-select-<?php echo $id; ?>" type="checkbox" name="id[]" value="<?php echo $id; ?>">
-                        <div class="locked-indicator">
-                            <span class="locked-indicator-icon" aria-hidden="true"></span>
-                            <span class="screen-reader-text"><?php echo $url; ?></span>
-                        </div>
-                    </th>
-                    <td><?php echo $url; ?></td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-</form>
+                <?php foreach( $view['urls'] as $id => $url ) : ?>
+                    <tr>
+                        <th scope="row" class="check-column">
+                            <label class="screen-reader-text" for="cb-select-<?php echo $id; ?>">
+                                Select <?php echo $url; ?>
+                            </label>
+                            <input id="cb-select-<?php echo $id; ?>" type="checkbox" name="id[]" value="<?php echo $id; ?>">
+                            <div class="locked-indicator">
+                                <span class="locked-indicator-icon" aria-hidden="true"></span>
+                                <span class="screen-reader-text"><?php echo $url; ?></span>
+                            </div>
+                        </th>
+                        <td><?php echo $url; ?></td>
+                    </tr>
+                <?php endforeach; ?>
+            </tbody>
+        </table>
+    </form>
+</div>

--- a/views/crawl-queue-page.php
+++ b/views/crawl-queue-page.php
@@ -1,23 +1,87 @@
 <br>
 
-<table class="widefat striped">
-    <thead>
-        <tr>
-            <th>URLs in Crawl Queue</th>
-        </tr>
-    </thead>
-    <tbody>
-        <?php if ( ! $view['urls'] ) : ?>
-            <tr>
-                <td>Crawl queue is empty.</td>
-            </tr>
-        <?php endif; ?>
+<form id="posts-filter" method="GET">
+    <input type="hidden" name="page" value="<?php echo $_GET['page']; ?>" />
 
-        <?php foreach( $view['urls'] as $url ) : ?>
-            <tr>
-                <td><?php echo $url; ?></td>
-            </tr>
-        <?php endforeach; ?>
-    </tbody>
-</table>
+    <p class="search-box">
+        <label class="screen-reader-text" for="post-search-input">Search Crawl Queue URLs:</label>
+        <input type="search" id="post-search-input" name="s" value="<?php echo esc_attr( @$_GET['s'] ); ?>">
+        <input type="submit" id="search-submit" class="button" value="Search URLs">
+    </p>
 
+    <div class="tablenav top">
+        <div class="alignleft actions bulkactions">
+			<label for="bulk-action-selector-top" class="screen-reader-text">Select bulk action</label>
+            <select name="action" id="bulk-action-selector-top">
+                <option value="-1">Bulk Actions</option>
+                <option value="remove">Remove</option>
+            </select>
+            <input type="submit" id="doaction" class="button action" value="Apply">
+		</div>
+	
+        <h2 class="screen-reader-text">Crawl Queue list navigation</h2>
+        <div class="tablenav-pages">
+            <span class="displaying-num"><?php echo number_format($view['total_count']); ?> items</span>
+            <span class="pagination-links">
+                <?php if ($view['page'] === 1): ?>
+                    <span class="tablenav-pages-navspan button disabled" aria-hidden="true">«</span>
+                    <span class="tablenav-pages-navspan button disabled" aria-hidden="true">‹</span>
+                <?php else: ?>
+                    <a class="first-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => 1]); ?>"><span class="screen-reader-text">First page</span><span aria-hidden="true">«</span></a>
+                    <a class="prev-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => $view['page'] - 1]); ?>"><span class="screen-reader-text">Previous page</span><span aria-hidden="true">‹</span></a>
+                <?php endif; ?>
+                <span class="paging-input">
+                    <label for="current-page-selector" class="screen-reader-text">Current Page</label>
+                    <input class="current-page" id="current-page-selector" type="text" name="paged" value="<?php echo $view['page']; ?>" size="3" aria-describedby="table-paging">
+                    <span class="tablenav-paging-text"> of 
+                        <span class="total-pages"><?php echo $view['pages']; ?></span>
+                    </span>
+                </span>
+                <?php if ($view['page'] === $view['pages']): ?>
+                    <span class="tablenav-pages-navspan button disabled" aria-hidden="true">›</span>
+                    <span class="tablenav-pages-navspan button disabled" aria-hidden="true">»</span>
+                <?php else: ?>
+                    <a class="next-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => $view['page'] + 1]); ?>"><span class="screen-reader-text">Next page</span><span aria-hidden="true">›</span></a>
+                    <a class="last-page button" href="<?php echo \WP2Static\URLHelper::modifyUrl(['paged' => $view['pages']]); ?>"><span class="screen-reader-text">Last page</span><span aria-hidden="true">»</span></a>
+                <?php endif; ?>
+            </span>
+        </div>
+		<br class="clear">
+    </div>
+
+    <table class="wp-list-table widefat striped">
+        <thead>
+            <tr>
+                <td id="cb" class="manage-column column-cb check-column">
+                    <label class="screen-reader-text" for="cb-select-all-1">Select All</label>
+                    <input id="cb-select-all-1" type="checkbox">
+                </td>
+                <th>URLs in Crawl Queue</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if ( ! $view['urls'] ) : ?>
+                <tr>
+                    <th>&nbsp;</th>
+                    <td>Crawl queue is empty.</td>
+                </tr>
+            <?php endif; ?>
+
+            <?php foreach( $view['urls'] as $id => $url ) : ?>
+                <tr>
+                    <th scope="row" class="check-column">
+                        <label class="screen-reader-text" for="cb-select-<?php echo $id; ?>">
+                            Select <?php echo $url; ?>
+                        </label>
+                        <input id="cb-select-<?php echo $id; ?>" type="checkbox" name="id[]" value="<?php echo $id; ?>">
+                        <div class="locked-indicator">
+                            <span class="locked-indicator-icon" aria-hidden="true"></span>
+                            <span class="screen-reader-text"><?php echo $url; ?></span>
+                        </div>
+                    </th>
+                    <td><?php echo $url; ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+</form>


### PR DESCRIPTION
My site has a very large number of URLs resulting in the crawl queue page being slow to load. This PR adds pagination, search and actions to the crawl queue page. Example image below:

![Screen Shot 2020-08-12 at 10 31 05 am](https://user-images.githubusercontent.com/334808/89962256-89ded800-dc87-11ea-802d-52bd16d15000.png)

If you're happy with this PR I can do the same for Crawl Cache, Generated Static Site etc pages.