### PR TITLE
Make all text inputs full-width

### DIFF
--- a/views/options-page.php
+++ b/views/options-page.php
@@ -118,6 +118,7 @@ function displayCheckbox($a = null, $b = null, $c = null) {
             </td>
             <td>
                 <input
+                    class="widefat"
                     id="<?php echo $view['coreOptions']['basicAuthUser']->name; ?>"
                     name="<?php echo $view['coreOptions']['basicAuthUser']->name; ?>"
                     type="text"
@@ -134,6 +135,7 @@ function displayCheckbox($a = null, $b = null, $c = null) {
             </td>
             <td>
                 <input
+                    class="widefat"
                     id="<?php echo $view['coreOptions']['basicAuthPassword']->name; ?>"
                     name="<?php echo $view['coreOptions']['basicAuthPassword']->name; ?>"
                     type="password"
@@ -150,6 +152,7 @@ function displayCheckbox($a = null, $b = null, $c = null) {
             </td>
             <td>
                 <input
+                    class="widefat"
                     id="<?php echo $view['coreOptions']['useCrawlCaching']->name; ?>"
                     name="<?php echo $view['coreOptions']['useCrawlCaching']->name; ?>"
                     value="1"
@@ -174,6 +177,7 @@ function displayCheckbox($a = null, $b = null, $c = null) {
             </td>
             <td>
                 <input
+                    class="widefat"
                     id="<?php echo $view['coreOptions']['deploymentURL']->name; ?>"
                     name="<?php echo $view['coreOptions']['deploymentURL']->name; ?>"
                     type="text"
@@ -196,7 +200,7 @@ function displayCheckbox($a = null, $b = null, $c = null) {
             </td>
             <td>
                 <input
-                    style="width:100%;"
+                    class="widefat"
                     type="email"
                     id="<?php echo $view['coreOptions']['completionEmail']->name; ?>"
                     name="<?php echo $view['coreOptions']['completionEmail']->name; ?>"


### PR DESCRIPTION
On the Options page there really isn't any reason not to make these inputs full width. Especially the site URL one could easily be longer than the current input provided.

Before:
![Screen Shot 2020-08-12 at 11 41 46 am](https://user-images.githubusercontent.com/334808/89965820-10e47e00-dc91-11ea-9793-e4229f3c96fa.png)

After:
![Screen Shot 2020-08-12 at 11 40 57 am](https://user-images.githubusercontent.com/334808/89965829-16da5f00-dc91-11ea-990b-2d93fcbe1681.png)
