### PR TITLE
Output logs while running CLI commands

### DIFF
--- a/src/WsLog.php
+++ b/src/WsLog.php
@@ -33,6 +33,13 @@ class WsLog {
                 'log' => $text,
             ]
         );
+
+        if (defined('WP_CLI')) {
+            $date = date('c');
+            \WP_CLI::log( 
+                \WP_CLI::colorize( "%W[$date] %n$text" )
+            );
+        }
     }
 
     /**

--- a/src/WsLog.php
+++ b/src/WsLog.php
@@ -34,9 +34,9 @@ class WsLog {
             ]
         );
 
-        if (defined('WP_CLI')) {
-            $date = date('c');
-            \WP_CLI::log( 
+        if ( defined( 'WP_CLI' ) ) {
+            $date = current_time( 'c' );
+            \WP_CLI::log(
                 \WP_CLI::colorize( "%W[$date] %n$text" )
             );
         }


### PR DESCRIPTION
While executing long-running CLI commands such as `wp wp2static crawl` there is no output at all so it's difficult to determine progress. This PR outputs logs go the CLI when executing commands. Example:

> $ wp wp2static crawl
> [2020-08-12T03:00:17+00:00] Starting to crawl detected URLs.
> [2020-08-12T03:00:17+00:00] Using CrawlCache.
> [2020-08-12T03:00:18+00:00] Crawling progress: 300 crawled, 2 skipped (cached).

If you don't want the logs to display, simply use the built-in `--quiet` argument like so:
```bash
$ wp wp2static crawl --quiet
```
