### PR TITLE
Add github workflow

### DIFF
--- a/.github/workflows/ci-php.yml
+++ b/.github/workflows/ci-php.yml
@@ -1,0 +1,46 @@
+# This is a basic workflow to help you get started with Actions
+name: CI - PHP
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on: [push, pull_request]
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  test:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php: [7.3.9]
+
+    name: PHP-${{ matrix.php }} 
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Cache PHP dependencies
+      uses: actions/cache@v1
+      with:
+        path: vendor
+        key: ${{ runner.OS }}-build-${{ hashFiles('**/composer.lock') }}
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+        coverage: none
+
+    - name: Validate Composer
+      run: composer validate --strict
+
+    - name: Install PHP dependencies
+      run: composer install --no-interaction --no-suggest
+
+    - name: Run our Linter and PHPStan
+      run: composer test


### PR DESCRIPTION
This repo receives a lot of pull requests. It would be convenient for you if PRs were tested before merge for lint and phpstan errors. We even had [a PR recently](https://github.com/WP2Static/wp2static/pull/615) where this issue was brought to light. 

Github Actions can help with this. It can automatically run the CI tools on PRs as well as general commits and show success/failures. Example [here](https://github.com/Flynsarmy/wp2static/runs/974195884) and you can see the green dot from my successful commit [here](https://github.com/Flynsarmy/wp2static/tree/githubActions).

If you're happy with this change, the circleci folder wont' be necessary anymore.