### PR TITLE
WIP: Rework Crawl Queue

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -747,4 +747,10 @@ class Controller {
 
         wp_die();
     }
+
+    public static function db_now() : string {
+        global $wpdb;
+
+        return $wpdb->get_col( 'SELECT NOW()' )[0];
+    }
 }

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -468,6 +468,14 @@ class Controller {
         exit;
     }
 
+    public static function wp2static_pre_post_update_handler( int $post_id ) : void {
+        $permalink = get_permalink( $post_id );
+        if ( $permalink ) {
+            $post_url = wp_make_link_relative( $permalink );
+            \WP2Static\CrawlQueue::clearCrawledTime( $post_url );
+        }
+    }
+
     public static function wp2static_save_post_handler( int $post_id ) : void {
         if ( CoreOptions::getValue( 'queueJobOnPostSave' ) &&
              get_post_status( $post_id ) === 'publish' ) {

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -176,6 +176,14 @@ class CoreOptions {
 
         $queries[] = $wpdb->prepare(
             $query_string,
+            'crawlChunkSize',
+            '20',
+            'Crawl Chunk Size',
+            'The number of URLs to crawl in one chunk.'
+        );
+
+        $queries[] = $wpdb->prepare(
+            $query_string,
             'crawlOnlyChangedUrls',
             '1',
             'Crawl only changed URLs.',
@@ -409,6 +417,12 @@ class CoreOptions {
                         ),
                     ],
                     [ 'name' => 'basicAuthPassword' ]
+                );
+
+                $wpdb->update(
+                    $table_name,
+                    [ 'value' => sanitize_text_field( $_POST['crawlChunkSize'] ) ],
+                    [ 'name' => 'crawlChunkSize' ]
                 );
 
                 $wpdb->update(

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -184,9 +184,9 @@ class CoreOptions {
 
         $queries[] = $wpdb->prepare(
             $query_string,
-            'crawlOnlyChangedUrls',
-            '1',
-            'Crawl only changed URLs.',
+            'crawlOnlyChangedURLs',
+            '0',
+            'Crawl Only Changed URLs',
             ''
         );
 
@@ -427,8 +427,8 @@ class CoreOptions {
 
                 $wpdb->update(
                     $table_name,
-                    [ 'value' => isset( $_POST['crawlOnlyChangedUrls'] ) ? 1 : 0 ],
-                    [ 'name' => 'crawlOnlyChangedUrls' ]
+                    [ 'value' => isset( $_POST['crawlOnlyChangedURLs'] ) ? 1 : 0 ],
+                    [ 'name' => 'crawlOnlyChangedURLs' ]
                 );
 
                 $wpdb->update(

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -176,6 +176,14 @@ class CoreOptions {
 
         $queries[] = $wpdb->prepare(
             $query_string,
+            'crawlOnlyChangedUrls',
+            '1',
+            'Crawl only changed URLs.',
+            ''
+        );
+
+        $queries[] = $wpdb->prepare(
+            $query_string,
             'useCrawlCaching',
             '1',
             'Use CrawlCache',
@@ -401,6 +409,12 @@ class CoreOptions {
                         ),
                     ],
                     [ 'name' => 'basicAuthPassword' ]
+                );
+
+                $wpdb->update(
+                    $table_name,
+                    [ 'value' => isset( $_POST['crawlOnlyChangedUrls'] ) ? 1 : 0 ],
+                    [ 'name' => 'crawlOnlyChangedUrls' ]
                 );
 
                 $wpdb->update(

--- a/src/CrawlQueue.php
+++ b/src/CrawlQueue.php
@@ -66,6 +66,22 @@ class CrawlQueue {
     }
 
     /**
+     * Set crawled_time to NULL for the URL.
+     *
+     * @param string $url The URL.
+     */
+    public static function clearCrawledTime( string $url ) : void {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wp2static_urls';
+        $query = $wpdb->prepare(
+            "UPDATE $table_name SET crawled_time = NULL WHERE url = %s",
+            $url
+        );
+        $wpdb->query( $query );
+    }
+
+    /**
      * Set crawled_time to NOW() for each URL.
      *
      * @param string[] $urls List of URLs.

--- a/src/CrawlQueue.php
+++ b/src/CrawlQueue.php
@@ -149,6 +149,30 @@ class CrawlQueue {
     }
 
     /**
+     * Get a chunk of URLs to crawl with null crawled_time.
+     *
+     * @param int $size Max number of URLs to return.
+     * @return array<string> Array of URLs.
+     */
+    public static function getChunkNulls( int $size ) : array {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wp2static_urls';
+
+        $rows = $wpdb->get_results(
+            "SELECT id, url FROM $table_name
+             WHERE crawled_time IS NULL
+             LIMIT $size"
+        );
+
+        $urls = [];
+        foreach ( $rows as $row ) {
+            $urls[ $row->id ] = $row->url;
+        }
+        return $urls;
+    }
+
+    /**
      * Remove multiple URLs at once
      *
      * @param array<string> $ids

--- a/src/CrawlQueue.php
+++ b/src/CrawlQueue.php
@@ -15,6 +15,7 @@ class CrawlQueue {
             id mediumint(9) NOT NULL AUTO_INCREMENT,
             url VARCHAR(2083) NOT NULL,
             hashed_url CHAR(32) NOT NULL,
+            crawled_time DATETIME,
             PRIMARY KEY  (id)
         ) $charset_collate;";
 
@@ -25,6 +26,11 @@ class CrawlQueue {
             $table_name,
             'hashed_url',
             "CREATE UNIQUE INDEX hashed_url ON $table_name (hashed_url)"
+        );
+        \WP2Static\Controller::ensure_index(
+            $table_name,
+            'crawled_time',
+            "CREATE INDEX crawled_time ON $table_name (crawled_time)"
         );
     }
 
@@ -60,6 +66,26 @@ class CrawlQueue {
     }
 
     /**
+     * Set crawled_time to NOW() for each URL.
+     *
+     * @param string[] $urls List of URLs.
+     */
+    public static function updateCrawledTimes( array $urls ) : void {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wp2static_urls';
+        $wpdb->query( 'START TRANSACTION' );
+        foreach ( $urls as $url ) {
+            $query = $wpdb->prepare(
+                "UPDATE $table_name SET crawled_time = NOW() WHERE url = %s",
+                $url
+            );
+            $wpdb->query( $query );
+        }
+        $wpdb->query( 'COMMIT' );
+    }
+
+    /**
      *  Get all crawlable URLs
      *
      *  @return string[] All crawlable URLs
@@ -76,6 +102,33 @@ class CrawlQueue {
             $urls[ $row->id ] = $row->url;
         }
 
+        return $urls;
+    }
+
+    /**
+     * Get a chunk of URLs to crawl.
+     *
+     * @param string $crawl_start_time Start time of the crawl.
+     * @param int $size Max number of URLs to return.
+     * @return array<string> Array of URLs.
+     */
+    public static function getChunk( string $crawl_start_time, int $size ) : array {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wp2static_urls';
+
+        $query = $wpdb->prepare(
+            "SELECT id, url FROM $table_name
+             WHERE crawled_time IS NULL OR crawled_time <= %s
+             LIMIT $size",
+            $crawl_start_time
+        );
+        $rows = $wpdb->get_results( $query );
+
+        $urls = [];
+        foreach ( $rows as $row ) {
+            $urls[ $row->id ] = $row->url;
+        }
         return $urls;
     }
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -91,7 +91,12 @@ class Crawler {
         $site_host = $site_port ? $site_host . ":$site_port" : $site_host;
         $site_urls = [ "http://$site_host", "https://$site_host" ];
 
-        $chunk_size = 20;
+        $chunk_size = intval( CoreOptions::getValue( 'crawlChunkSize' ) );
+        if ( $chunk_size < 1 ) {
+            $chunk_size = PHP_INT_MAX;
+        }
+        WsLog::l( "Crawling with a chunk size of $chunk_size");
+
         $use_crawl_cache = apply_filters(
             'wp2static_use_crawl_cache',
             CoreOptions::getValue( 'useCrawlCaching' )

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -20,7 +20,7 @@ class ViewRenderer {
             'detectUploads' => CoreOptions::get( 'detectUploads' ),
             'deploymentURL' => CoreOptions::get( 'deploymentURL' ),
             'crawlChunkSize' => CoreOptions::get( 'crawlChunkSize' ),
-            'crawlOnlyChangedUrls' => CoreOptions::get( 'crawlOnlyChangedUrls' ),
+            'crawlOnlyChangedURLs' => CoreOptions::get( 'crawlOnlyChangedURLs' ),
             'useCrawlCaching' => CoreOptions::get( 'useCrawlCaching' ),
         ];
 

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -19,6 +19,7 @@ class ViewRenderer {
             'detectPosts' => CoreOptions::get( 'detectPosts' ),
             'detectUploads' => CoreOptions::get( 'detectUploads' ),
             'deploymentURL' => CoreOptions::get( 'deploymentURL' ),
+            'crawlOnlyChangedUrls' => CoreOptions::get( 'crawlOnlyChangedUrls' ),
             'useCrawlCaching' => CoreOptions::get( 'useCrawlCaching' ),
         ];
 

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -19,6 +19,7 @@ class ViewRenderer {
             'detectPosts' => CoreOptions::get( 'detectPosts' ),
             'detectUploads' => CoreOptions::get( 'detectUploads' ),
             'deploymentURL' => CoreOptions::get( 'deploymentURL' ),
+            'crawlChunkSize' => CoreOptions::get( 'crawlChunkSize' ),
             'crawlOnlyChangedUrls' => CoreOptions::get( 'crawlOnlyChangedUrls' ),
             'useCrawlCaching' => CoreOptions::get( 'useCrawlCaching' ),
         ];

--- a/src/WordPressAdmin.php
+++ b/src/WordPressAdmin.php
@@ -254,6 +254,12 @@ class WordPressAdmin {
         );
 
         add_action(
+            'pre_post_update',
+            [ 'WP2Static\Controller', 'wp2static_pre_post_update_handler' ],
+            0
+        );
+
+        add_action(
             'save_post',
             [ 'WP2Static\Controller', 'wp2static_save_post_handler' ],
             0
@@ -303,4 +309,3 @@ class WordPressAdmin {
         }
     }
 }
-

--- a/views/options-page.php
+++ b/views/options-page.php
@@ -165,16 +165,16 @@ function displayCheckbox($a = null, $b = null, $c = null) {
             <tr>
                 <td>
                     <label
-                        for="<?php echo $view['coreOptions']['crawlOnlyChangedUrls']->name; ?>"
-                    ><?php echo $view['coreOptions']['crawlOnlyChangedUrls']->label; ?></label>
+                        for="<?php echo $view['coreOptions']['crawlOnlyChangedURLs']->name; ?>"
+                    ><?php echo $view['coreOptions']['crawlOnlyChangedURLs']->label; ?></label>
                 </td>
                 <td>
                     <input
-                        id="<?php echo $view['coreOptions']['crawlOnlyChangedUrls']->name; ?>"
-                        name="<?php echo $view['coreOptions']['crawlOnlyChangedUrls']->name; ?>"
+                        id="<?php echo $view['coreOptions']['crawlOnlyChangedURLs']->name; ?>"
+                        name="<?php echo $view['coreOptions']['crawlOnlyChangedURLs']->name; ?>"
                         value="1"
                         type="checkbox"
-                        <?php echo (int) $view['coreOptions']['crawlOnlyChangedUrls']->value === 1 ? 'checked' : ''; ?>
+                        <?php echo (int) $view['coreOptions']['crawlOnlyChangedURLs']->value === 1 ? 'checked' : ''; ?>
                     />
                 </td>
             </tr>

--- a/views/options-page.php
+++ b/views/options-page.php
@@ -146,6 +146,23 @@ function displayCheckbox($a = null, $b = null, $c = null) {
             </tr>
 
             <tr>
+                <td style="width:50%;">
+                    <label
+                        for="<?php echo $view['coreOptions']['crawlChunkSize']->name; ?>"
+                    ><?php echo $view['coreOptions']['crawlChunkSize']->label; ?></label>
+                </td>
+                <td>
+                    <input
+                        class="widefat"
+                        id="<?php echo $view['coreOptions']['crawlChunkSize']->name; ?>"
+                        name="<?php echo $view['coreOptions']['crawlChunkSize']->name; ?>"
+                        type="text"
+                        value="<?php echo $view['coreOptions']['crawlChunkSize']->value !== '' ? $view['coreOptions']['crawlChunkSize']->value : ''; ?>"
+                    />
+                </td>
+            </tr>
+
+            <tr>
                 <td>
                     <label
                         for="<?php echo $view['coreOptions']['crawlOnlyChangedUrls']->name; ?>"

--- a/views/options-page.php
+++ b/views/options-page.php
@@ -148,6 +148,23 @@ function displayCheckbox($a = null, $b = null, $c = null) {
             <tr>
                 <td>
                     <label
+                        for="<?php echo $view['coreOptions']['crawlOnlyChangedUrls']->name; ?>"
+                    ><?php echo $view['coreOptions']['crawlOnlyChangedUrls']->label; ?></label>
+                </td>
+                <td>
+                    <input
+                        id="<?php echo $view['coreOptions']['crawlOnlyChangedUrls']->name; ?>"
+                        name="<?php echo $view['coreOptions']['crawlOnlyChangedUrls']->name; ?>"
+                        value="1"
+                        type="checkbox"
+                        <?php echo (int) $view['coreOptions']['crawlOnlyChangedUrls']->value === 1 ? 'checked' : ''; ?>
+                    />
+                </td>
+            </tr>
+
+            <tr>
+                <td>
+                    <label
                         for="<?php echo $view['coreOptions']['useCrawlCaching']->name; ?>"
                     ><?php echo $view['coreOptions']['useCrawlCaching']->label; ?></label>
                 </td>


### PR DESCRIPTION
Add a crawled_time column to the URL and crawl URLs in chunks. This will make it easier to implement other features.

I made a site with 10,000 small posts to do some unscientific timing tests. The server is Debian 10, NGINX, PHP 7.4, on a t3a.micro EC2 instance.
Crawling before these changes: 6:11, 6:09, 6:11
Crawling while updating crawled_time individually: 9:35
Crawling while updating crawled_time in chunks: 8:02, 7:51, 8:15

The slowdown is measurable, but not terrible. It will probably be a much lower % of the total in real sites which take longer to generate pages. Next up: crawling only pages that have changed since the last crawl.