### PR TITLE
Add some FilesHelper tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "wp-coding-standards/wpcs": "*",
         "phpcompatibility/php-compatibility": "*",
         "php-parallel-lint/php-parallel-lint": "*",
-        "10up/wp_mock": "^0.4.2"
+        "10up/wp_mock": "^0.4.2",
+        "mikey179/vfsstream": "^1.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7baeda382f69ca24a7267df1eaace8f1",
+    "content-hash": "ea1125c00ed02b6a9ede41b2b9f5adc8",
     "packages": [
         {
             "name": "wa72/url",
@@ -320,6 +320,52 @@
                 "test"
             ],
             "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2019-10-30T15:31:00+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7baeda382f69ca24a7267df1eaace8f1",
+    "content-hash": "ea1125c00ed02b6a9ede41b2b9f5adc8",
     "packages": [
         {
             "name": "wa72/url",
@@ -322,6 +322,52 @@
             "time": "2020-07-09T08:09:16+00:00"
         },
         {
+            "name": "mikey179/vfsstream",
+            "version": "v1.6.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bovigo/vfsStream.git",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "org\\bovigo\\vfs\\": "src/main/php"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Frank Kleine",
+                    "homepage": "http://frankkleine.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Virtual file system to mock the real file system in unit tests.",
+            "homepage": "http://vfs.bovigo.org/",
+            "time": "2019-10-30T15:31:00+00:00"
+        },
+        {
             "name": "mockery/mockery",
             "version": "1.4.2",
             "source": {
@@ -445,16 +491,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.8.0",
+            "version": "v4.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "8c58eb4cd4f3883f82611abeac2efbc3dbed787e"
+                "reference": "aaee038b912e567780949787d5fe1977be11a778"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8c58eb4cd4f3883f82611abeac2efbc3dbed787e",
-                "reference": "8c58eb4cd4f3883f82611abeac2efbc3dbed787e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/aaee038b912e567780949787d5fe1977be11a778",
+                "reference": "aaee038b912e567780949787d5fe1977be11a778",
                 "shasum": ""
             },
             "require": {
@@ -462,7 +508,7 @@
                 "php": ">=7.0"
             },
             "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.6",
+                "ircmaxell/php-yacc": "^0.0.7",
                 "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
@@ -471,7 +517,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8-dev"
+                    "dev-master": "4.9-dev"
                 }
             },
             "autoload": {
@@ -493,7 +539,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-08-09T10:23:20+00:00"
+            "time": "2020-08-18T19:48:01+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -653,16 +699,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.4.2",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "38b0963698ca5858658a5b09198062411f22932a"
+                "reference": "7ea14fc5e4242255f6b48295fdda0512053f0dc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/38b0963698ca5858658a5b09198062411f22932a",
-                "reference": "38b0963698ca5858658a5b09198062411f22932a",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/7ea14fc5e4242255f6b48295fdda0512053f0dc1",
+                "reference": "7ea14fc5e4242255f6b48295fdda0512053f0dc1",
                 "shasum": ""
             },
             "replace": {
@@ -689,7 +735,7 @@
                 "static analysis",
                 "wordpress"
             ],
-            "time": "2020-06-11T14:56:54+00:00"
+            "time": "2020-08-18T04:31:49+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -960,16 +1006,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.37",
+            "version": "0.12.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "5e16d83e6eb2dd784fbdaeaece5e2bca72e4f68a"
+                "reference": "ad606c5f1c641b465b739e79a3a0f1a5a57cf1b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/5e16d83e6eb2dd784fbdaeaece5e2bca72e4f68a",
-                "reference": "5e16d83e6eb2dd784fbdaeaece5e2bca72e4f68a",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ad606c5f1c641b465b739e79a3a0f1a5a57cf1b4",
+                "reference": "ad606c5f1c641b465b739e79a3a0f1a5a57cf1b4",
                 "shasum": ""
             },
             "require": {
@@ -1012,7 +1058,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-09T14:32:41+00:00"
+            "time": "2020-08-19T08:13:30+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2463,16 +2509,16 @@
         },
         {
             "name": "szepeviktor/phpstan-wordpress",
-            "version": "v0.6.2",
+            "version": "v0.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "f621f7d6e7cd6c649c41d77092d4f869a837beed"
+                "reference": "d3ff2a9c0f3c336f352061524253c79ccc5ae30f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/f621f7d6e7cd6c649c41d77092d4f869a837beed",
-                "reference": "f621f7d6e7cd6c649c41d77092d4f869a837beed",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/d3ff2a9c0f3c336f352061524253c79ccc5ae30f",
+                "reference": "d3ff2a9c0f3c336f352061524253c79ccc5ae30f",
                 "shasum": ""
             },
             "require": {
@@ -2519,7 +2565,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2020-07-01T02:05:01+00:00"
+            "time": "2020-08-21T09:36:29+00:00"
         },
         {
             "name": "thecodingmachine/phpstan-strict-rules",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea1125c00ed02b6a9ede41b2b9f5adc8",
+    "content-hash": "7baeda382f69ca24a7267df1eaace8f1",
     "packages": [
         {
             "name": "wa72/url",
@@ -320,52 +320,6 @@
                 "test"
             ],
             "time": "2020-07-09T08:09:16+00:00"
-        },
-        {
-            "name": "mikey179/vfsstream",
-            "version": "v1.6.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
-                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.5|^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "org\\bovigo\\vfs\\": "src/main/php"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Frank Kleine",
-                    "homepage": "http://frankkleine.de/",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Virtual file system to mock the real file system in unit tests.",
-            "homepage": "http://vfs.bovigo.org/",
-            "time": "2019-10-30T15:31:00+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/src/FilesHelper.php
+++ b/src/FilesHelper.php
@@ -71,6 +71,9 @@ class FilesHelper {
         return $files;
     }
 
+    /**
+     * Ensure a given filepath has an allowed filename and extension.
+     */
     public static function filePathLooksCrawlable( string $file_name ) : bool {
         $filenames_to_ignore = [
             '__MACOSX',

--- a/src/FilesHelper.php
+++ b/src/FilesHelper.php
@@ -74,7 +74,7 @@ class FilesHelper {
     /**
      * Ensure a given filepath has an allowed filename and extension.
      *
-     * @return bool  True if the given file does not have a blacklisted filename
+     * @return bool  True if the given file does not have a disallowed filename
      *               or extension.
      */
     public static function filePathLooksCrawlable( string $file_name ) : bool {

--- a/src/FilesHelper.php
+++ b/src/FilesHelper.php
@@ -36,9 +36,9 @@ class FilesHelper {
     }
 
     /**
-     * Get public URLs for all files in a local directory
+     * Get public URLs for all files in a local directory.
      *
-     * @return string[] list of URLs
+     * @return string[] list of relative, urlencoded URLs
      */
     public static function getListOfLocalFilesByDir( string $dir ) : array {
         $files = [];
@@ -73,6 +73,9 @@ class FilesHelper {
 
     /**
      * Ensure a given filepath has an allowed filename and extension.
+     *
+     * @return bool  True if the given file does not have a blacklisted filename
+     *               or extension.
      */
     public static function filePathLooksCrawlable( string $file_name ) : bool {
         $filenames_to_ignore = [
@@ -179,10 +182,11 @@ class FilesHelper {
     }
 
     /**
-     * Clean all detected URLs before use
+     * Clean all detected URLs before use. Accepts relative and absolute URLs
+     * both with and without starting or trailing slashes.
      *
-     * @param string[] $urls list of URLs
-     * @return string[] list of URLs
+     * @param string[] $urls list of absolute or relative URLs
+     * @return string[] list of relative URLs
      * @throws WP2StaticException
      */
     public static function cleanDetectedURLs( array $urls ) : array {
@@ -235,4 +239,3 @@ class FilesHelper {
         return $cleaned_urls;
     }
 }
-

--- a/tests/unit/FileHelperTest.php
+++ b/tests/unit/FileHelperTest.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace WP2Static;
+
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+
+final class FileHelperTest extends TestCase {
+    public function setUp() : void {
+        WP_Mock::setUp();
+    }
+
+    public function tearDown() : void {
+        WP_Mock::tearDown();
+    }
+
+    /**
+     * Test filePathLooksCrawlable method
+     * 
+     * @todo Add tests for wp2static_file_extensions_to_ignore and
+     *  wp2static_filenames_to_ignore filters.
+     *
+     * @return void
+     */
+    public function testFilePathLooksCrawlable() {
+        // Default accepted extension
+        $expected = true;
+        $actual = FilesHelper::filePathLooksCrawlable( "/path/to/foo.jpg" );
+        $this->assertEquals( $expected, $actual );
+
+        // Default disallowed extension
+        $expected = false;
+        $actual = FilesHelper::filePathLooksCrawlable( "/path/to/foo.txt" );
+        $this->assertEquals( $expected, $actual );
+
+        // Default disallowed filename
+        $expected = false;
+        $actual = FilesHelper::filePathLooksCrawlable( "/path/to/thumbs.db" );
+        $this->assertEquals( $expected, $actual );
+    }
+
+    public function testFilePathLooksCrawlableExtensionFilter() {
+        // txt extensions should be disallowed
+        $expected = false;
+        $actual = FilesHelper::filePathLooksCrawlable( "/path/to/foo.txt" );
+        $this->assertEquals( $expected, $actual );
+
+        // Here we're changing which fil eextensions are no longer allowed.
+        \WP_Mock::onFilter( 'wp2static_file_extensions_to_ignore' )
+            ->with([
+                '.bat',
+                '.crt',
+                '.DS_Store',
+                '.git',
+                '.idea',
+                '.ini',
+                '.less',
+                '.map',
+                '.md',
+                '.mo',
+                '.php',
+                '.PHP',
+                '.phtml',
+                '.po',
+                '.pot',
+                '.scss',
+                '.sh',
+                '.sql',
+                '.SQL',
+                '.tar.gz',
+                '.tpl',
+                '.txt',
+                '.yarn',
+                '.zip',
+            ])
+            ->reply(['.unknown']);
+        // We've disallowed .unknown - test it
+        $expected = false;
+        $actual = FilesHelper::filePathLooksCrawlable( "/path/to/foo.unknown" );
+        $this->assertEquals( $expected, $actual );
+
+        // txt extensions should now be allowed - test it
+        $expected = true;
+        $actual = FilesHelper::filePathLooksCrawlable( "/path/to/foo.txt" );
+        $this->assertEquals( $expected, $actual );
+    }
+
+    public function testFilePathLooksCrawlableFilenameFilter() {
+        // thumbs.db filenames are currently disallowed
+        $expected = false;
+        $actual = FilesHelper::filePathLooksCrawlable( "/path/to/thumbs.db" );
+        $this->assertEquals( $expected, $actual );
+
+        // Here we're changing which fil eextensions are no longer allowed.
+        \WP_Mock::onFilter( 'wp2static_filenames_to_ignore' )
+            ->with([
+                '__MACOSX',
+                '.babelrc',
+                '.gitignore',
+                '.gitkeep',
+                '.htaccess',
+                '.php',
+                '.travis.yml',
+                'backwpup',
+                'bower_components',
+                'bower.json',
+                'composer.json',
+                'composer.lock',
+                'config.rb',
+                'current-export',
+                'Dockerfile',
+                'gulpfile.js',
+                'latest-export',
+                'LICENSE',
+                'Makefile',
+                'node_modules',
+                'package.json',
+                'pb_backupbuddy',
+                'plugins/wp2static',
+                'previous-export',
+                'README',
+                'static-html-output-plugin',
+                'thumbs.db',
+                'tinymce',
+                'wc-logs',
+                'wpallexport',
+                'wpallimport',
+                'wp-static-html-output', // exclude earlier version exports
+                'wp2static-addon',
+                'wp2static-crawled-site',
+                'wp2static-processed-site',
+                'wp2static-working-files',
+                'yarn-error.log',
+                'yarn.lock',
+            ])
+            ->reply(['yarn.lock']);
+        // We've disallowed yarn.lock - test it
+        $expected = false;
+        $actual = FilesHelper::filePathLooksCrawlable( "/path/to/yarn.lock" );
+        $this->assertEquals( $expected, $actual );
+
+        // thumbs.db filenames should now be allowed - test it
+        $expected = true;
+        $actual = FilesHelper::filePathLooksCrawlable( "/path/to/thumbs.db" );
+        $this->assertEquals( $expected, $actual );
+    }
+
+    public function testCleanDetectedURLs() {
+        // Mock the WP functions used by FilesHelper::cleanDetectedURLs()
+        $mock = \Mockery::mock('alias:WP2Static\SiteInfo')
+            ->shouldReceive('getUrl')
+            ->andReturn('https://foo.com/');
+
+        // No trailing slash
+        $expected = ['/foo'];
+        $actual = FilesHelper::cleanDetectedURLs(["https://foo.com/foo"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Trailing slash
+        $expected = ['/foo/'];
+        $actual = FilesHelper::cleanDetectedURLs(["https://foo.com/foo/"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Double trailing slash
+        $expected = ['/foo/'];
+        $actual = FilesHelper::cleanDetectedURLs(["https://foo.com/foo//"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Double middle slash
+        $expected = ['/foo/'];
+        $actual = FilesHelper::cleanDetectedURLs(["https://foo.com//foo/"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Single URL param - no trailing slash
+        $expected = ['foo'];
+        $actual = FilesHelper::cleanDetectedURLs(["foo"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Single URL param - trailing slash
+        $expected = ['foo/'];
+        $actual = FilesHelper::cleanDetectedURLs(["foo/"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Single URL param - starting + trailing slash
+        $expected = ['/foo/'];
+        $actual = FilesHelper::cleanDetectedURLs(["/foo/"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Single URL param - double trailing slash
+        $expected = ['foo/'];
+        $actual = FilesHelper::cleanDetectedURLs(["foo//"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Single URL param - double starting slash
+        $expected = ['/foo'];
+        $actual = FilesHelper::cleanDetectedURLs(["//foo"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Single URL param - double starting + trailing slash
+        $expected = ['/foo/'];
+        $actual = FilesHelper::cleanDetectedURLs(["//foo//"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Two URL params, Trailing slash
+        $expected = ['/foo/bar/'];
+        $actual = FilesHelper::cleanDetectedURLs(["https://foo.com/foo/bar/"]);
+        $this->assertEquals( $expected, $actual );
+
+        // Two URL params, Double middle slash
+        $expected = ['/foo/bar/'];
+        $actual = FilesHelper::cleanDetectedURLs(["https://foo.com/foo//bar/"]);
+        $this->assertEquals( $expected, $actual );
+    }
+}


### PR DESCRIPTION
I'm not super familiar with testing so this is my first attempt at using Mockery and WP_Mock. I added tests to a few FilesHelper methods. Not all the methods are tested yet but I figured I'd just check you guys are happy with how I've done things here before continuing.

I'm not sure yet how to test `getListOfLocalFilesByDir` as it relies on the result of `filePathLooksCrawlable` which is another static method - so I can't mock `filePathLooksCrawlable`'s response.

I also don't like the huge arrays needed in WP_Mock::onFilter. I created an issue in their repo [here](https://github.com/10up/wp_mock/issues/156) describing my problem with it and a potential fix. Perhaps a solution to my problem already exists and I'm just not aware of it.

And finally I'm not sure if the output from `testCleanDetectedURLs` is intended to work the way it does, I just added tests for everything I could think of so we can see as plainly as possible how it's currently working. Up to you guys to decide if you like the way starting/trailing slashes work with it.