### PR TITLE
Make all FileHelper methods camelCase

### DIFF
--- a/src/FilesHelper.php
+++ b/src/FilesHelper.php
@@ -13,7 +13,7 @@ class FilesHelper {
      *
      * @throws WP2StaticException
      */
-    public static function delete_dir_with_files( string $dir ) : void {
+    public static function deleteDirWithFiles( string $dir ) : void {
         if ( is_dir( $dir ) ) {
             $dir_files = scandir( $dir );
 
@@ -27,7 +27,7 @@ class FilesHelper {
 
             foreach ( $files as $file ) {
                 ( is_dir( "$dir/$file" ) ) ?
-                self::delete_dir_with_files( "$dir/$file" ) :
+                self::deleteDirWithFiles( "$dir/$file" ) :
                 unlink( "$dir/$file" );
             }
 

--- a/src/ProcessedSite.php
+++ b/src/ProcessedSite.php
@@ -41,7 +41,7 @@ class ProcessedSite {
         WsLog::l( 'Deleting ProcessedSite files' );
 
         if ( is_dir( self::getPath() ) ) {
-            FilesHelper::delete_dir_with_files( self::getPath() );
+            FilesHelper::deleteDirWithFiles( self::getPath() );
         }
     }
 

--- a/src/StaticSite.php
+++ b/src/StaticSite.php
@@ -44,7 +44,7 @@ class StaticSite {
         WsLog::l( 'Deleting StaticSite files' );
 
         if ( is_dir( self::getPath() ) ) {
-            FilesHelper::delete_dir_with_files( self::getPath() );
+            FilesHelper::deleteDirWithFiles( self::getPath() );
 
             // CrawlCache not useful without StaticSite files
             CrawlCache::truncate();

--- a/tests/unit/FileHelperTest.php
+++ b/tests/unit/FileHelperTest.php
@@ -17,7 +17,7 @@ final class FileHelperTest extends TestCase {
     }
 
     /**
-     * Test delete_dir_with_files method
+     * Test deleteDirWithFiles method
      *
      * @return void
      */
@@ -61,7 +61,7 @@ final class FileHelperTest extends TestCase {
 
         // Delete the unicode subfolder
         $filepath = vfsStream::url('root/top_level_ùnicodë_folder/sêcond_level_fÒlder');
-        FilesHelper::delete_dir_with_files($filepath);
+        FilesHelper::deleteDirWithFiles($filepath);
         // Confirm it's gone
         $expected = false;
         $actual = is_dir( $filepath );
@@ -74,7 +74,7 @@ final class FileHelperTest extends TestCase {
 
         // Delete a subfolder with spaces in the filename
         $filepath = vfsStream::url('root/top level folder with spaces/only a subfolder');
-        FilesHelper::delete_dir_with_files($filepath);
+        FilesHelper::deleteDirWithFiles($filepath);
         // Confirm it's gone
         $expected = false;
         $actual = is_dir( $filepath );


### PR DESCRIPTION
We had a single slug_case method in this class so this PR simply makes it camelCase to fit with all other methods of the class.