### PR TITLE
Add SimpleRewriter tests

### DIFF
--- a/src/SimpleRewriter.php
+++ b/src/SimpleRewriter.php
@@ -11,40 +11,44 @@ namespace WP2Static;
 class SimpleRewriter {
 
     /**
-     * SimpleRewriter constructor
-     */
-    public function __construct() {
-
-    }
-
-    /**
      * Rewrite URLs in file to destination_url
      *
      * @param string $filename file to rewrite URLs in
      * @throws WP2StaticException
      */
     public static function rewrite( string $filename ) : void {
+        $file_contents = file_get_contents( $filename );
+
+        $rewritten_contents = self::rewriteFileContents( $file_contents );
+
+        file_put_contents( $filename, $rewritten_contents );
+    }
+
+    /**
+     * Rewrite URLs in a string to destination_url
+     *
+     * @param string $file_contents
+     * @return string
+     */
+    public static function rewriteFileContents( string $file_contents ) : string
+    {
+        // TODO: allow empty file saving here? Exception for style.css
+        if ( ! $file_contents ) {
+            return '';
+        }
+
         $destination_url = apply_filters(
             'wp2static_set_destination_url',
             CoreOptions::getValue( 'deploymentURL' )
         );
 
-        $wordpress_site_url =
-            apply_filters(
-                'wp2static_set_wordpress_site_url',
-                untrailingslashit( SiteInfo::getUrl( 'site' ) )
-            );
-
-        $file_contents = file_get_contents( $filename );
-
-        // TODO: allow empty file saving here? Exception for style.css
-        if ( ! $file_contents ) {
-            return;
-        }
+        $wordpress_site_url = apply_filters(
+            'wp2static_set_wordpress_site_url',
+            trailingslashit( SiteInfo::getUrl( 'site' ) )
+        );
 
         $search_patterns = [
             trailingslashit( $wordpress_site_url ),
-            $wordpress_site_url,
             addcslashes( $wordpress_site_url, '/' ),
             addcslashes( trailingslashit( $wordpress_site_url ), '/' ),
             URLHelper::getProtocolRelativeURL( $wordpress_site_url ),
@@ -53,7 +57,6 @@ class SimpleRewriter {
 
         $replace_patterns = [
             trailingslashit( $destination_url ),
-            $destination_url,
             addcslashes( $destination_url, '/' ),
             addcslashes( trailingslashit( $destination_url ), '/' ),
             URLHelper::getProtocolRelativeURL( $destination_url ),
@@ -66,7 +69,7 @@ class SimpleRewriter {
             $file_contents
         );
 
-        file_put_contents( $filename, $rewritten_contents );
+        return $rewritten_contents;
     }
 }
 

--- a/src/SimpleRewriter.php
+++ b/src/SimpleRewriter.php
@@ -55,10 +55,12 @@ class SimpleRewriter {
         $destination_url = untrailingslashit( $destination_url );
 
         $search_patterns = [
+            $wordpress_site_url,
             URLHelper::getProtocolRelativeURL( $wordpress_site_url ),
             addcslashes( URLHelper::getProtocolRelativeURL( $wordpress_site_url ), '/' ),
         ];
         $replace_patterns = [
+            $destination_url,
             URLHelper::getProtocolRelativeURL( $destination_url ),
             addcslashes( URLHelper::getProtocolRelativeURL( $destination_url ), '/' ),
         ];

--- a/src/SimpleRewriter.php
+++ b/src/SimpleRewriter.php
@@ -48,19 +48,17 @@ class SimpleRewriter {
 
         $wordpress_site_url = apply_filters(
             'wp2static_set_wordpress_site_url',
-            trailingslashit( SiteInfo::getUrl( 'site' ) )
+            untrailingslashit( SiteInfo::getUrl( 'site' ) )
         );
 
+        $wordpress_site_url = untrailingslashit( $wordpress_site_url );
+        $destination_url = untrailingslashit( $destination_url );
+
         $search_patterns = [
-            addcslashes( $wordpress_site_url, '/' ),
-            addcslashes( trailingslashit( $wordpress_site_url ), '/' ),
             URLHelper::getProtocolRelativeURL( $wordpress_site_url ),
             addcslashes( URLHelper::getProtocolRelativeURL( $wordpress_site_url ), '/' ),
         ];
-
         $replace_patterns = [
-            addcslashes( $destination_url, '/' ),
-            addcslashes( trailingslashit( $destination_url ), '/' ),
             URLHelper::getProtocolRelativeURL( $destination_url ),
             addcslashes( URLHelper::getProtocolRelativeURL( $destination_url ), '/' ),
         ];

--- a/src/SimpleRewriter.php
+++ b/src/SimpleRewriter.php
@@ -19,6 +19,10 @@ class SimpleRewriter {
     public static function rewrite( string $filename ) : void {
         $file_contents = file_get_contents( $filename );
 
+        if ( $file_contents === false ) {
+            $file_contents = '';
+        }
+
         $rewritten_contents = self::rewriteFileContents( $file_contents );
 
         file_put_contents( $filename, $rewritten_contents );
@@ -48,7 +52,6 @@ class SimpleRewriter {
         );
 
         $search_patterns = [
-            trailingslashit( $wordpress_site_url ),
             addcslashes( $wordpress_site_url, '/' ),
             addcslashes( trailingslashit( $wordpress_site_url ), '/' ),
             URLHelper::getProtocolRelativeURL( $wordpress_site_url ),
@@ -56,7 +59,6 @@ class SimpleRewriter {
         ];
 
         $replace_patterns = [
-            trailingslashit( $destination_url ),
             addcslashes( $destination_url, '/' ),
             addcslashes( trailingslashit( $destination_url ), '/' ),
             URLHelper::getProtocolRelativeURL( $destination_url ),

--- a/tests/unit/FileHelperTest.php
+++ b/tests/unit/FileHelperTest.php
@@ -7,6 +7,10 @@ use org\bovigo\vfs\vfsStream;
 use WP_Mock;
 use WP_Mock\Tools\TestCase;
 
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
 final class FileHelperTest extends TestCase {
 
     public function setUp() : void
@@ -17,6 +21,7 @@ final class FileHelperTest extends TestCase {
     public function tearDown() : void
     {
         WP_Mock::tearDown();
+        Mockery::close();
     }
 
     /**

--- a/tests/unit/SimpleRewriterTest.php
+++ b/tests/unit/SimpleRewriterTest.php
@@ -18,14 +18,6 @@ final class SimpleRewriterTest extends TestCase {
         WP_Mock::setUp();
 
         // Mock the methods and functions used by SimpleRewriter
-        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
-            ->shouldreceive( 'getValue' )
-            ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' );
-        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
-            ->shouldreceive( 'getUrl' )
-            ->withArgs( [ 'site' ] )
-            ->andReturn( 'https://foo.com/' );
         Mockery::mock( 'overload:\WP2Static\URLHelper' )
             ->shouldreceive( 'getProtocolRelativeURL' )
             ->andReturnUsing( [ $this, 'getProtocolRelativeURL' ] );
@@ -45,6 +37,16 @@ final class SimpleRewriterTest extends TestCase {
      * @return void
      */
     public function testRewrite() {
+        // Mock the methods and functions used by SimpleRewriter
+        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+            ->shouldreceive( 'getValue' )
+            ->withArgs( [ 'deploymentURL' ] )
+            ->andReturn( 'https://bar.com' );
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'https://foo.com/' );
+        
         // Set up a virual file to rewriting
         $structure = [
             'my-file.html' => 'my-file.html',
@@ -98,6 +100,16 @@ final class SimpleRewriterTest extends TestCase {
      * @dataProvider rewriteFileContentsProvider
      */
     public function testRewriteFileContents( $raw_html, $expected ) {
+        // Mock the methods and functions used by SimpleRewriter
+        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+            ->shouldreceive( 'getValue' )
+            ->withArgs( [ 'deploymentURL' ] )
+            ->andReturn( 'https://bar.com' );
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'https://foo.com/' );
+
         $actual = SimpleRewriter::rewriteFileContents( $raw_html );
         $this->assertEquals( $expected, $actual );
 
@@ -106,10 +118,58 @@ final class SimpleRewriterTest extends TestCase {
         $this->assertEquals( addcslashes( $expected, '/' ), $actual );
     }
 
+    public function testRewriteFileContentsHttpToHttps() {
+        // Mock the methods and functions used by SimpleRewriter
+        $deploymentMock = Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+            ->shouldreceive( 'getValue' )
+            ->withArgs( [ 'deploymentURL' ] )
+            ->andReturn( 'https://bar.com' )
+            ->getMock();
+        $siteUrlMock = Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'http://foo.com/' )
+            ->getMock();
+
+        // http -> https
+        $expected = 'https://bar.com/somepath';
+        $actual = SimpleRewriter::rewriteFileContents( 'http://foo.com/somepath' );
+        $this->assertEquals( $expected, $actual );
+    }
+
+    public function testRewriteFileContentsHttpsToHttp() {
+        // Mock the methods and functions used by SimpleRewriter
+        $deploymentMock = Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+            ->shouldreceive( 'getValue' )
+            ->withArgs( [ 'deploymentURL' ] )
+            ->andReturn( 'http://bar.com' )
+            ->getMock();
+        $siteUrlMock = Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'https://foo.com/' )
+            ->getMock();
+
+        // http -> https
+        $expected = 'http://bar.com/somepath';
+        $actual = SimpleRewriter::rewriteFileContents( 'https://foo.com/somepath' );
+        $this->assertEquals( $expected, $actual );
+    }
+
     /**
      * @dataProvider rewriteFileContentsProvider
      */
     public function testRewriteFileContentsDestinationUrlFilter( $raw_html, $expected ) {
+        // Mock the methods and functions used by SimpleRewriter
+        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+            ->shouldreceive( 'getValue' )
+            ->withArgs( [ 'deploymentURL' ] )
+            ->andReturn( 'https://bar.com' );
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'https://foo.com/' );
+
         // Test a deployment URL on a subdirectory
         \WP_Mock::onFilter( 'wp2static_set_destination_url' )
             ->with( 'https://bar.com' )
@@ -129,6 +189,16 @@ final class SimpleRewriterTest extends TestCase {
      * @dataProvider rewriteFileContentsProvider
      */
     public function testRewriteFileContentsSiteUrlFilter( $raw_html, $expected ) {
+        // Mock the methods and functions used by SimpleRewriter
+        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+            ->shouldreceive( 'getValue' )
+            ->withArgs( [ 'deploymentURL' ] )
+            ->andReturn( 'https://bar.com' );
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'https://foo.com/' );
+
         // Test a deployment URL on a subdirectory
         \WP_Mock::onFilter( 'wp2static_set_wordpress_site_url' )
             ->with( 'https://foo.com' )

--- a/tests/unit/SimpleRewriterTest.php
+++ b/tests/unit/SimpleRewriterTest.php
@@ -97,6 +97,11 @@ final class SimpleRewriterTest extends TestCase {
         $actual = SimpleRewriter::rewriteFileContents( 'https://foo.com//bar/baz' );
         $this->assertEquals( $expected, $actual );
 
+        // Protocol relative URLs are being rewritten
+        $expected = '//bar.com/bar/baz';
+        $actual = SimpleRewriter::rewriteFileContents( '//foo.com/bar/baz' );
+        $this->assertEquals( $expected, $actual );
+
     }
 
     /**

--- a/tests/unit/SimpleRewriterTest.php
+++ b/tests/unit/SimpleRewriterTest.php
@@ -16,6 +16,25 @@ final class SimpleRewriterTest extends TestCase {
     public function setUp() : void
     {
         WP_Mock::setUp();
+
+        // Mock the methods and functions used by SimpleRewriter
+        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+            ->shouldreceive( 'getValue' )
+            ->withArgs( [ 'deploymentURL' ] )
+            ->andReturn( 'https://bar.com' );
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'https://foo.com' );
+        Mockery::mock( 'overload:\WP2Static\URLHelper' )
+            ->shouldreceive( 'getProtocolRelativeURL' )
+            ->andReturnUsing( [ $this, 'getProtocolRelativeURL' ] );
+        WP_Mock::userFunction(
+            'trailingslashit',
+            [
+                'return_arg' => 0,
+            ]
+        );
     }
 
     public function tearDown() : void
@@ -38,25 +57,6 @@ final class SimpleRewriterTest extends TestCase {
         vfsStream::create( $structure, $vfs );
         $filepath = vfsStream::url( 'root/my-file.html' );
 
-        // Mock the methods and functions used by SimpleRewriter
-        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
-            ->shouldreceive( 'getValue' )
-            ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' );
-        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
-            ->shouldreceive( 'getUrl' )
-            ->withArgs( [ 'site' ] )
-            ->andReturn( 'https://foo.com' );
-        Mockery::mock( 'overload:\WP2Static\URLHelper' )
-            ->shouldreceive( 'getProtocolRelativeURL' )
-            ->andReturnUsing( [ $this, 'getProtocolRelativeURL' ] );
-        WP_Mock::userFunction(
-            'trailingslashit',
-            [
-                'return_arg' => 0,
-            ]
-        );
-
         // We're performing a rewrite and updating the file correctly
         file_put_contents( $filepath, 'https://foo.com' );
         SimpleRewriter::rewrite( $filepath );
@@ -71,25 +71,6 @@ final class SimpleRewriterTest extends TestCase {
      * @return void
      */
     public function testRewriteFileContents() {
-        // Mock the methods and functions used by SimpleRewriter
-        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
-            ->shouldreceive( 'getValue' )
-            ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' );
-        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
-            ->shouldreceive( 'getUrl' )
-            ->withArgs( [ 'site' ] )
-            ->andReturn( 'https://foo.com' );
-        Mockery::mock( 'overload:\WP2Static\URLHelper' )
-            ->shouldreceive( 'getProtocolRelativeURL' )
-            ->andReturnUsing( [ $this, 'getProtocolRelativeURL' ] );
-        WP_Mock::userFunction(
-            'trailingslashit',
-            [
-                'return_arg' => 0,
-            ]
-        );
-
         $expected = 'a file with no change needed';
         $actual = SimpleRewriter::rewriteFileContents( 'a file with no change needed' );
         $this->assertEquals( $expected, $actual );

--- a/tests/unit/SimpleRewriterTest.php
+++ b/tests/unit/SimpleRewriterTest.php
@@ -46,7 +46,7 @@ final class SimpleRewriterTest extends TestCase {
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )
             ->andReturn( 'https://foo.com/' );
-        
+
         // Set up a virual file to rewriting
         $structure = [
             'my-file.html' => 'my-file.html',
@@ -120,12 +120,12 @@ final class SimpleRewriterTest extends TestCase {
 
     public function testRewriteFileContentsHttpToHttps() {
         // Mock the methods and functions used by SimpleRewriter
-        $deploymentMock = Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
             ->andReturn( 'https://bar.com' )
             ->getMock();
-        $siteUrlMock = Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )
             ->andReturn( 'http://foo.com/' )
@@ -139,12 +139,12 @@ final class SimpleRewriterTest extends TestCase {
 
     public function testRewriteFileContentsHttpsToHttp() {
         // Mock the methods and functions used by SimpleRewriter
-        $deploymentMock = Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
             ->andReturn( 'http://bar.com' )
             ->getMock();
-        $siteUrlMock = Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )
             ->andReturn( 'https://foo.com/' )

--- a/tests/unit/SimpleRewriterTest.php
+++ b/tests/unit/SimpleRewriterTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace WP2Static;
+
+use Mockery;
+use org\bovigo\vfs\vfsStream;
+use WP_Mock;
+use WP_Mock\Tools\TestCase;
+
+final class SimpleRewriterTest extends TestCase {
+
+    public function setUp() : void
+    {
+        WP_Mock::setUp();
+
+        // Mock the methods and functions used by SimpleRewriter
+        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+            ->shouldreceive( 'getValue' )
+            ->withArgs( [ 'deploymentURL' ] )
+            ->andReturn( 'https://bar.com' );
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'https://foo.com' );
+        Mockery::mock( 'overload:\WP2Static\URLHelper' )
+            ->shouldreceive( 'getProtocolRelativeURL' )
+            ->andReturnUsing( [ $this, 'getProtocolRelativeURL' ] );
+        WP_Mock::userFunction(
+            'trailingslashit',
+            [
+                'return_arg' => 0,
+            ]
+        );
+    }
+
+    public function tearDown() : void
+    {
+        WP_Mock::tearDown();
+    }
+
+    /**
+     * Test deleteDirWithFiles method
+     *
+     * @return void
+     */
+    public function testRewrite() {
+        // Set up a virual file to rewriting
+        $structure = [
+            'my-file.html' => 'my-file.html',
+        ];
+        $vfs = vfsStream::setup( 'root' );
+        vfsStream::create( $structure, $vfs );
+        $filepath = vfsStream::url( 'root/my-file.html' );
+
+        // We're performing a rewrite and updating the file correctly
+        file_put_contents( $filepath, 'https://foo.com' );
+        SimpleRewriter::rewrite( $filepath );
+        $expected = 'https://bar.com';
+        $actual = file_get_contents( $filepath );
+        $this->assertEquals( $expected, $actual );
+    }
+
+    /**
+     * Test deleteDirWithFiles method
+     *
+     * @return void
+     */
+    public function testRewriteFileContents() {
+        $expected = 'a file with no change needed';
+        $actual = SimpleRewriter::rewriteFileContents( 'a file with no change needed' );
+        $this->assertEquals( $expected, $actual );
+
+        // We're rewriting WP to Destination URL correctly (without trailing slash)
+        $expected = 'https://bar.com';
+        $actual = SimpleRewriter::rewriteFileContents( 'https://foo.com' );
+        $this->assertEquals( $expected, $actual );
+
+        // We're rewriting WP to Destination URL correctly (with trailing slash)
+        $expected = 'https://bar.com/';
+        $actual = SimpleRewriter::rewriteFileContents( 'https://foo.com/' );
+        $this->assertEquals( $expected, $actual );
+
+        // Multiple URLs are being rewritten
+        $expected = 'multiple https://bar.com occurances https://bar.com present';
+        $actual = SimpleRewriter::rewriteFileContents(
+            'multiple https://foo.com occurances https://foo.com present'
+        );
+        $this->assertEquals( $expected, $actual );
+
+        // URLs with params are being rewritten
+        $expected = 'https://bar.com/bar/baz';
+        $actual = SimpleRewriter::rewriteFileContents( 'https://foo.com/bar/baz' );
+        $this->assertEquals( $expected, $actual );
+
+        // @todo URLs are not being cleaned correctly. Is this OK?
+        $expected = 'https://bar.com//bar/baz';
+        $actual = SimpleRewriter::rewriteFileContents( 'https://foo.com//bar/baz' );
+        $this->assertEquals( $expected, $actual );
+
+    }
+
+    /**
+     * Reimplimentation of URLHelper::getProtocolRelativeURL specific for our
+     * test.
+     *
+     * @param string $url
+     * @return string
+     */
+    public function getProtocolRelativeURL( string $url ): string {
+        return str_replace(
+            [
+                'https:',
+                'http:',
+            ],
+            [
+                '',
+                '',
+            ],
+            $url
+        );
+    }
+}

--- a/tests/unit/SimpleRewriterTest.php
+++ b/tests/unit/SimpleRewriterTest.php
@@ -112,10 +112,10 @@ final class SimpleRewriterTest extends TestCase {
     public function testRewriteFileContentsDestinationUrlFilter( $raw_html, $expected ) {
         // Test a deployment URL on a subdirectory
         \WP_Mock::onFilter( 'wp2static_set_destination_url' )
-            ->with('https://bar.com')
-            ->reply('https://bar.com/somepath');
+            ->with( 'https://bar.com' )
+            ->reply( 'https://bar.com/somepath' );
 
-        $expected = str_replace('bar.com', 'bar.com/somepath', $expected);
+        $expected = str_replace( 'bar.com', 'bar.com/somepath', $expected );
 
         $actual = SimpleRewriter::rewriteFileContents( $raw_html );
         $this->assertEquals( $expected, $actual );
@@ -131,10 +131,10 @@ final class SimpleRewriterTest extends TestCase {
     public function testRewriteFileContentsSiteUrlFilter( $raw_html, $expected ) {
         // Test a deployment URL on a subdirectory
         \WP_Mock::onFilter( 'wp2static_set_wordpress_site_url' )
-            ->with('https://foo.com')
-            ->reply('https://foo.com/somepath/');
+            ->with( 'https://foo.com' )
+            ->reply( 'https://foo.com/somepath/' );
 
-        $raw_html = str_replace('foo.com', 'foo.com/somepath', $raw_html);
+        $raw_html = str_replace( 'foo.com', 'foo.com/somepath', $raw_html );
 
         $actual = SimpleRewriter::rewriteFileContents( $raw_html );
         $this->assertEquals( $expected, $actual );

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -3,3 +3,15 @@
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 WP_Mock::bootstrap();
+
+if ( ! function_exists( 'untrailingslashit' ) ) {
+    function untrailingslashit( $string ) {
+        return rtrim( $string, '/\\' );
+    }
+}
+
+if ( ! function_exists( 'trailingslashit' ) ) {
+    function trailingslashit( $string ) {
+        return rtrim( $string, '/\\' ) . '/';
+    }
+}


### PR DESCRIPTION
This PR adds tests for `SimpleRewriter` class.

* Removed unused constructor
* Split the actual rewriting part to its own method for better testability (and separation of concerns)
* Simplified the rewrite behavior a little
* Added runTestsInSeparateProcesses comment to classes with Mockery aliases. See https://laracasts.com/discuss/channels/testing/mocking-a-class-persists-over-tests?reply=103075

Other notes:
* Should we have some sort of check for what we should do if `file_get_contents` fails?
* Rather than assign the rewritten contents of `$file_contents` variable to the `$rewritten_contents` variable, should we just overwrite `$file_contents` instead? I'm not sure how PHP memory efficiency works in this respect. I'd assume we're using twice as much memory (now 4x as much with my separate `rewriteFileContents` method) the way we're doing it at the moment.