### PR TITLE
Add more detection tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,9 +56,9 @@
     },
     "scripts": {
         "phpstan": "php -d memory_limit=-1 ./vendor/bin/phpstan analyse",
-        "phpcs": "vendor/bin/phpcs --standard=./tools/phpcs.xml --ignore=*/tests/phpstan/*,*/admin/*,**/coverage/*,*.js,*/vendor/*,*/views/*.php ./",
+        "phpcbf": "vendor/bin/phpcbf --standard=./tools/phpcs.xml --ignore=*/js/*,*/tests/phpstan/*,*/admin/*,*/coverage/*,*.js,*/vendor/*,*/views/*.php ./",
+        "phpcs":  "vendor/bin/phpcs  --standard=./tools/phpcs.xml --ignore=*/tests/phpstan/*,*/admin/*,**/coverage/*,*.js,*/vendor/*,*/views/*.php ./",
         "phpcompat": "vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.3 --ignore=*/tests/*,*/admin/*,**/coverage/*,*.js,*/vendor/*,*/views/*.php ./",
-        "phpcbf": "vendor/bin/phpcbf --standard=./tools/phpcs.xml --ignore=*/js/*,*/tests/*,*/admin/*,*/coverage/*,*.js,*/vendor/*,*/views/*.php ./",
         "phpunit": "vendor/bin/phpunit ./tests/unit/",
         "coverage": "vendor/bin/phpunit tests/unit --coverage-html coverage --whitelist src/",
         "lint": "vendor/bin/parallel-lint --exclude vendor .",

--- a/src/DetectArchiveURLs.php
+++ b/src/DetectArchiveURLs.php
@@ -9,13 +9,13 @@ class DetectArchiveURLs {
      *
      * Get list of archive URLs
      * ie
-     *      /2020/04/
-     *      /2020/05/
-     *      /2020/
+     *      https://foo.com/2020/04/
+     *      https://foo.com/2020/05/
+     *      https://foo.com/2020/
      *
      * @return string[] list of archive URLs
      */
-    public static function detect( string $wp_site_url ) : array {
+    public static function detect() : array {
         global $wpdb;
 
         $archive_urls = [];
@@ -55,14 +55,6 @@ class DetectArchiveURLs {
         $url_matching_regex = '#\bhttps?://[^,\s()<>]+(?:\([\w\d]+\)|([^,[:punct:]\s]|/))#';
         preg_match_all( $url_matching_regex, $archive_urls_with_markup, $matches );
 
-        foreach ( $matches[0] as $url ) {
-            $archive_urls[] = str_replace(
-                $wp_site_url,
-                '/',
-                $url
-            );
-        }
-
-        return $archive_urls;
+        return $matches[0];
     }
 }

--- a/src/DetectAttachmentURLs.php
+++ b/src/DetectAttachmentURLs.php
@@ -13,24 +13,16 @@ class DetectAttachmentURLs {
         global $wpdb;
 
         $post_urls = [];
-        $unique_post_types = [];
 
-        $query = "
-            SELECT ID,post_type
-            FROM %s
-            WHERE post_status = '%s'
-            AND post_type = 'attachment'";
-
-        $posts = $wpdb->get_results(
-            sprintf(
-                $query,
-                $wpdb->posts,
-                'publish'
-            )
+        $post_ids = $wpdb->get_col(
+            "SELECT ID
+            FROM {$wpdb->posts}
+            WHERE post_status = 'publish'
+            AND post_type = 'attachment'"
         );
 
-        foreach ( $posts as $post ) {
-            $permalink = get_attachment_link( $post->ID );
+        foreach ( $post_ids as $post_id ) {
+            $permalink = get_attachment_link( $post_id );
 
             if ( strpos( $permalink, '?post_type' ) !== false ) {
                 continue;

--- a/src/DetectAttachmentURLs.php
+++ b/src/DetectAttachmentURLs.php
@@ -9,7 +9,7 @@ class DetectAttachmentURLs {
      *
      * @return string[] list of URLs
      */
-    public static function detect() : array {
+    public static function detect( string $wp_site_url ) : array {
         global $wpdb;
 
         $post_urls = [];
@@ -17,8 +17,7 @@ class DetectAttachmentURLs {
         $post_ids = $wpdb->get_col(
             "SELECT ID
             FROM {$wpdb->posts}
-            WHERE post_status = 'publish'
-            AND post_type = 'attachment'"
+            WHERE post_type = 'attachment'"
         );
 
         foreach ( $post_ids as $post_id ) {
@@ -28,7 +27,11 @@ class DetectAttachmentURLs {
                 continue;
             }
 
-            $post_urls[] = $permalink;
+            $post_urls[] = str_replace(
+                $wp_site_url,
+                '/',
+                $permalink
+            );
         }
 
         return $post_urls;

--- a/src/DetectAttachmentURLs.php
+++ b/src/DetectAttachmentURLs.php
@@ -9,7 +9,7 @@ class DetectAttachmentURLs {
      *
      * @return string[] list of URLs
      */
-    public static function detect( string $wp_site_url ) : array {
+    public static function detect() : array {
         global $wpdb;
 
         $post_urls = [];
@@ -27,11 +27,7 @@ class DetectAttachmentURLs {
                 continue;
             }
 
-            $post_urls[] = str_replace(
-                $wp_site_url,
-                '/',
-                $permalink
-            );
+            $post_urls[] = $permalink;
         }
 
         return $post_urls;

--- a/src/DetectAuthorsURLs.php
+++ b/src/DetectAuthorsURLs.php
@@ -9,7 +9,7 @@ class DetectAuthorsURLs {
      *
      * @return string[] list of URLs
      */
-    public static function detect( string $wp_site_url ) : array {
+    public static function detect() : array {
         global $wp_rewrite, $wpdb;
 
         $authors_urls = [];
@@ -24,13 +24,7 @@ class DetectAuthorsURLs {
 
             $permalink = trim( $author_link );
 
-            $author_url = str_replace(
-                $wp_site_url,
-                '',
-                $permalink
-            );
-
-            $authors_urls [] = '/' . $author_url;
+            $authors_urls[] = $permalink;
         }
 
         return $authors_urls;

--- a/src/DetectCategoryPaginationURLs.php
+++ b/src/DetectCategoryPaginationURLs.php
@@ -9,7 +9,7 @@ class DetectCategoryPaginationURLs {
      *
      * @return string[] list of URLs
      */
-    public static function detect( string $wp_site_url ) : array {
+    public static function detect() : array {
         global $wp_rewrite, $wpdb;
 
         // first we get each category with total posts as an array
@@ -40,11 +40,7 @@ class DetectCategoryPaginationURLs {
 
                 $total_posts = $term->count;
 
-                $term_url = str_replace(
-                    $wp_site_url,
-                    '',
-                    $permalink
-                );
+                $term_url = $permalink;
 
                 $category_links[ $term_url ] = $total_posts;
             }
@@ -55,7 +51,7 @@ class DetectCategoryPaginationURLs {
 
             for ( $page = 1; $page <= $total_pages; $page++ ) {
                 $urls_to_include[] =
-                    "/{$term}{$pagination_base}/{$page}";
+                    "{$term}{$pagination_base}/{$page}";
             }
         }
 

--- a/src/DetectCategoryURLs.php
+++ b/src/DetectCategoryURLs.php
@@ -9,7 +9,7 @@ class DetectCategoryURLs {
      *
      * @return string[] list of URLs
      */
-    public static function detect( string $wp_site_url ) : array {
+    public static function detect() : array {
         global $wp_rewrite, $wpdb;
 
         $args = [ 'public' => true ];
@@ -34,13 +34,7 @@ class DetectCategoryURLs {
 
                 $permalink = trim( $term_link );
 
-                $term_url = str_replace(
-                    $wp_site_url,
-                    '',
-                    $permalink
-                );
-
-                $category_urls[] = "/$term_url";
+                $category_urls[] = $permalink;
             }
         }
 

--- a/src/DetectCommentPaginationURLs.php
+++ b/src/DetectCommentPaginationURLs.php
@@ -9,11 +9,11 @@ class DetectCommentPaginationURLs {
      *
      * @return string[] list of URLs
      */
-    public static function detect( string $wp_site_url ) : array {
+    public static function detect() : array {
         global $wp_rewrite;
 
         $urls_to_include = [];
-        $comments_pagination_base = $wp_rewrite->comments_pagination_base;
+        // $comments_pagination_base = $wp_rewrite->comments_pagination_base;
         $comments = get_comments();
 
         if ( ! is_iterable( $comments ) ) {
@@ -28,11 +28,7 @@ class DetectCommentPaginationURLs {
                 continue;
             }
 
-            $urls_to_include[] = str_replace(
-                $wp_site_url,
-                '',
-                $comment_url
-            );
+            $urls_to_include[] = $comment_url;
         }
 
         return array_unique( $urls_to_include );

--- a/src/DetectCustomPostTypeURLs.php
+++ b/src/DetectCustomPostTypeURLs.php
@@ -15,20 +15,11 @@ class DetectCustomPostTypeURLs {
         $post_urls = [];
         $unique_post_types = [];
 
-        $query = "
-            SELECT ID,post_type
-            FROM %s
-            WHERE post_status = '%s'
-            AND post_type NOT IN ('%s','%s')";
-
         $posts = $wpdb->get_results(
-            sprintf(
-                $query,
-                $wpdb->posts,
-                'publish',
-                'revision',
-                'nav_menu_item'
-            )
+            "SELECT ID,post_type
+            FROM {$wpdb->posts}
+            WHERE post_status = 'publish'
+            AND post_type NOT IN ('revision','nav_menu_item')"
         );
 
         foreach ( $posts as $post ) {

--- a/src/DetectCustomPostTypeURLs.php
+++ b/src/DetectCustomPostTypeURLs.php
@@ -13,20 +13,16 @@ class DetectCustomPostTypeURLs {
         global $wpdb;
 
         $post_urls = [];
-        $unique_post_types = [];
 
-        $posts = $wpdb->get_results(
-            "SELECT ID,post_type
+        $post_ids = $wpdb->get_col(
+            "SELECT ID
             FROM {$wpdb->posts}
             WHERE post_status = 'publish'
             AND post_type NOT IN ('revision','nav_menu_item')"
         );
 
-        foreach ( $posts as $post ) {
-            // capture all post types
-            $unique_post_types[] = $post->post_type;
-
-            $permalink = get_post_permalink( $post->ID );
+        foreach ( $post_ids as $post_id ) {
+            $permalink = get_post_permalink( $post_id );
 
             if ( ! is_string( $permalink ) ) {
                 continue;

--- a/src/DetectPageURLs.php
+++ b/src/DetectPageURLs.php
@@ -14,22 +14,15 @@ class DetectPageURLs {
 
         $page_urls = [];
 
-        $query = "
-            SELECT ID
+        $page_ids = $wpdb->get_col(
+            "SELECT ID
             FROM %s
-            WHERE post_status = '%s'
-            AND post_type = 'page'";
-
-        $pages = $wpdb->get_results(
-            sprintf(
-                $query,
-                $wpdb->posts,
-                'publish'
-            )
+            WHERE post_status = 'publish'
+            AND post_type = 'page'"
         );
 
-        foreach ( $pages as $page ) {
-            $permalink = get_page_link( $page->ID );
+        foreach ( $page_ids as $page_id ) {
+            $permalink = get_page_link( $page_id );
 
             if ( strpos( $permalink, '?post_type' ) !== false ) {
                 continue;

--- a/src/DetectPageURLs.php
+++ b/src/DetectPageURLs.php
@@ -16,7 +16,7 @@ class DetectPageURLs {
 
         $page_ids = $wpdb->get_col(
             "SELECT ID
-            FROM %s
+            FROM {$wpdb->posts}
             WHERE post_status = 'publish'
             AND post_type = 'page'"
         );

--- a/src/DetectPostURLs.php
+++ b/src/DetectPostURLs.php
@@ -14,27 +14,20 @@ class DetectPostURLs {
 
         $post_urls = [];
 
-        $query = "
-            SELECT ID
-            FROM %s
-            WHERE post_status = '%s'
-            AND post_type = 'post'";
-
-        $posts = $wpdb->get_results(
-            sprintf(
-                $query,
-                $wpdb->posts,
-                'publish'
-            )
+        $post_ids = $wpdb->get_col(
+            "SELECT ID
+            FROM {$wpdb->posts}
+            WHERE post_status = 'publish'
+            AND post_type = 'post'"
         );
 
-        foreach ( $posts as $post ) {
+        foreach ( $post_ids as $post_id ) {
             $permalink = WPOverrides::get_permalink(
-                $post->ID,
+                $post_id,
                 $permalink_structure
             );
 
-            $permalink = WPOverrides::get_permalink( $post->ID, $permalink );
+            $permalink = WPOverrides::get_permalink( $post_id, $permalink );
 
             if ( ! $permalink ) {
                 continue;

--- a/src/DetectPostURLs.php
+++ b/src/DetectPostURLs.php
@@ -27,8 +27,6 @@ class DetectPostURLs {
                 $permalink_structure
             );
 
-            $permalink = WPOverrides::get_permalink( $post_id, $permalink );
-
             if ( ! $permalink ) {
                 continue;
             }

--- a/src/URLDetector.php
+++ b/src/URLDetector.php
@@ -104,25 +104,25 @@ class URLDetector {
         $detect_archives = apply_filters( 'wp2static_detect_archives', 1 );
 
         if ( $detect_archives ) {
-            $arrays_to_merge[] = DetectArchiveURLs::detect( SiteInfo::getUrl( 'site' ) );
+            $arrays_to_merge[] = DetectArchiveURLs::detect();
         }
 
         $detect_categories = apply_filters( 'wp2static_detect_categories', 1 );
 
         if ( $detect_categories ) {
-            $arrays_to_merge[] = DetectCategoryURLs::detect( SiteInfo::getUrl( 'site' ) );
+            $arrays_to_merge[] = DetectCategoryURLs::detect();
         }
 
         $detect_category_pagination = apply_filters( 'wp2static_detect_category_pagination', 1 );
 
         if ( $detect_category_pagination ) {
-            $arrays_to_merge[] = DetectCategoryPaginationURLs::detect( SiteInfo::getUrl( 'site' ) );
+            $arrays_to_merge[] = DetectCategoryPaginationURLs::detect();
         }
 
         $detect_authors = apply_filters( 'wp2static_detect_authors', 1 );
 
         if ( $detect_authors ) {
-            $arrays_to_merge[] = DetectAuthorsURLs::detect( SiteInfo::getUrl( 'site' ) );
+            $arrays_to_merge[] = DetectAuthorsURLs::detect();
         }
 
         $detect_authors_pagination = apply_filters( 'wp2static_detect_authors_pagination', 1 );

--- a/tests/unit/DetectArchiveURLsTest.php
+++ b/tests/unit/DetectArchiveURLsTest.php
@@ -66,20 +66,20 @@ final class DetectArchiveURLsTest extends TestCase {
         );
 
         $expected = [
-            '/archives/2020/',
-            '/archives/2019/',
-            '/archives/2018/',
-            '/archives/2017/',
-            '/archives/2020/08/',
-            '/archives/2020/07/',
-            '/archives/2020/06/',
-            '/archives/2020/05/',
-            '/archives/2020/08/20/',
-            '/archives/2020/08/17/',
-            '/archives/2020/08/16/',
-            '/archives/2020/08/15/',
+            "{$site_url}archives/2020/",
+            "{$site_url}archives/2019/",
+            "{$site_url}archives/2018/",
+            "{$site_url}archives/2017/",
+            "{$site_url}archives/2020/08/",
+            "{$site_url}archives/2020/07/",
+            "{$site_url}archives/2020/06/",
+            "{$site_url}archives/2020/05/",
+            "{$site_url}archives/2020/08/20/",
+            "{$site_url}archives/2020/08/17/",
+            "{$site_url}archives/2020/08/16/",
+            "{$site_url}archives/2020/08/15/",
         ];
-        $actual = DetectArchiveURLs::detect( $site_url );
+        $actual = DetectArchiveURLs::detect();
         $this->assertEquals( $expected, $actual );
     }
 }

--- a/tests/unit/DetectArchiveURLsTest.php
+++ b/tests/unit/DetectArchiveURLsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace WP2Static;
+
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+final class DetectArchiveURLsTest extends TestCase {
+
+
+    public function testDetect() {
+        $site_url = 'https://foo.com/';
+
+        \WP_Mock::userFunction(
+            'wp_get_archives',
+            [
+                'times' => 1,
+                'args' => [
+                    [
+                        'type' => 'yearly',
+                        'echo' => 0,
+                    ],
+                ],
+                'return' =>
+                    "<li><a href='{$site_url}archives/2020/'>2020</a></li>
+                    <li><a href='{$site_url}archives/2019/'>2019</a></li>
+                    <li><a href='{$site_url}archives/2018/'>2018</a></li>
+                    <li><a href='{$site_url}archives/2017/'>2017</a></li>",
+            ]
+        );
+
+        \WP_Mock::userFunction(
+            'wp_get_archives',
+            [
+                'times' => 1,
+                'args' => [
+                    [
+                        'type' => 'monthly',
+                        'echo' => 0,
+                    ],
+                ],
+                'return' =>
+                    "<li><a href='{$site_url}archives/2020/08/'>August 2020</a></li>
+                    <li><a href='{$site_url}archives/2020/07/'>July 2020</a></li>
+                    <li><a href='{$site_url}archives/2020/06/'>June 2020</a></li>
+                    <li><a href='{$site_url}archives/2020/05/'>May 2020</a></li>",
+            ]
+        );
+
+        \WP_Mock::userFunction(
+            'wp_get_archives',
+            [
+                'times' => 1,
+                'args' => [
+                    [
+                        'type' => 'daily',
+                        'echo' => 0,
+                    ],
+                ],
+                'return' =>
+                    "<li><a href='{$site_url}archives/2020/08/20/'>August 20, 2020</a></li>
+                    <li><a href='{$site_url}archives/2020/08/17/'>August 17, 2020</a></li>
+                    <li><a href='{$site_url}archives/2020/08/16/'>August 16, 2020</a></li>
+                    <li><a href='{$site_url}archives/2020/08/15/'>August 15, 2020</a></li>",
+            ]
+        );
+
+        $expected = [
+            '/archives/2020/',
+            '/archives/2019/',
+            '/archives/2018/',
+            '/archives/2017/',
+            '/archives/2020/08/',
+            '/archives/2020/07/',
+            '/archives/2020/06/',
+            '/archives/2020/05/',
+            '/archives/2020/08/20/',
+            '/archives/2020/08/17/',
+            '/archives/2020/08/16/',
+            '/archives/2020/08/15/',
+        ];
+        $actual = DetectArchiveURLs::detect( $site_url );
+        $this->assertEquals( $expected, $actual );
+    }
+}

--- a/tests/unit/DetectAttachmentURLsTest.php
+++ b/tests/unit/DetectAttachmentURLsTest.php
@@ -34,9 +34,9 @@ final class DetectAttachmentURLsTest extends TestCase {
         }
 
         $expected = [
-            "{$site_url}attachment-1/",
-            "{$site_url}attachment-2/",
-            "{$site_url}attachment-3/",
+            '/attachment-1/',
+            '/attachment-2/',
+            '/attachment-3/',
         ];
         $actual = DetectAttachmentURLs::detect( $site_url );
         $this->assertEquals( $expected, $actual );

--- a/tests/unit/DetectAttachmentURLsTest.php
+++ b/tests/unit/DetectAttachmentURLsTest.php
@@ -34,11 +34,11 @@ final class DetectAttachmentURLsTest extends TestCase {
         }
 
         $expected = [
-            '/attachment-1/',
-            '/attachment-2/',
-            '/attachment-3/',
+            "{$site_url}attachment-1/",
+            "{$site_url}attachment-2/",
+            "{$site_url}attachment-3/",
         ];
-        $actual = DetectAttachmentURLs::detect( $site_url );
+        $actual = DetectAttachmentURLs::detect();
         $this->assertEquals( $expected, $actual );
     }
 }

--- a/tests/unit/DetectAttachmentURLsTest.php
+++ b/tests/unit/DetectAttachmentURLsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WP2Static;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+final class DetectAttachmentURLsTest extends TestCase {
+
+
+    public function testDetect() {
+        global $wpdb;
+        $site_url = 'https://foo.com/';
+
+        // Create 3 attachments
+        // @phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+        $wpdb = Mockery::mock( '\WPDB' );
+        $wpdb->shouldReceive( 'get_col' )
+            ->once()
+            ->andReturn( [ 1, 2, 3 ] );
+        $wpdb->posts = 'wp_posts';
+
+        // And URLs for them
+        for ( $i = 1; $i <= 3; $i++ ) {
+            \WP_Mock::userFunction(
+                'get_attachment_link',
+                [
+                    'times' => 1,
+                    'args' => [ $i ],
+                    'return' => "{$site_url}attachment-{$i}/",
+                ]
+            );
+        }
+
+        $expected = [
+            "{$site_url}attachment-1/",
+            "{$site_url}attachment-2/",
+            "{$site_url}attachment-3/",
+        ];
+        $actual = DetectAttachmentURLs::detect( $site_url );
+        $this->assertEquals( $expected, $actual );
+    }
+}

--- a/tests/unit/DetectAuthorsURLsTest.php
+++ b/tests/unit/DetectAuthorsURLsTest.php
@@ -35,8 +35,12 @@ final class DetectAuthorsURLsTest extends TestCase {
             ]
         );
 
-        $expected = [ '/users/1', '/users/2', '/users/3' ];
-        $actual = DetectAuthorsURLs::detect( $site_url );
+        $expected = [
+            "{$site_url}users/1",
+            "{$site_url}users/2",
+            "{$site_url}users/3",
+        ];
+        $actual = DetectAuthorsURLs::detect();
         $this->assertEquals( $expected, $actual );
     }
 }

--- a/tests/unit/DetectCategoryPaginationURLsTest.php
+++ b/tests/unit/DetectCategoryPaginationURLsTest.php
@@ -12,17 +12,29 @@ final class DetectCategoryPaginationURLsTest extends TestCase {
     public function testDetect() {
         $site_url = 'https://foo.com/';
         $taxonomies = [
-            (object)['name' => 'category'],
-            (object)['name' => 'post_tag'],
+            (object) [ 'name' => 'category' ],
+            (object) [ 'name' => 'post_tag' ],
         ];
         $terms = [
             'category' => [
-                'category1' => (object)['name' => 'category1', 'count' => 1],
-                'category2' => (object)['name' => 'category2', 'count' => 3],
-                'category3' => (object)['name' => 'category3', 'count' => 4],
+                'category1' => (object) [
+                    'name' => 'category1',
+                    'count' => 1,
+                ],
+                'category2' => (object) [
+                    'name' => 'category2',
+                    'count' => 3,
+                ],
+                'category3' => (object) [
+                    'name' => 'category3',
+                    'count' => 4,
+                ],
             ],
             'post_tag' => [
-                'post_tag1' => (object)['name' => 'post_tag1', 'count' => 14],
+                'post_tag1' => (object) [
+                    'name' => 'post_tag1',
+                    'count' => 14,
+                ],
             ],
         ];
         $term_links = [
@@ -32,9 +44,10 @@ final class DetectCategoryPaginationURLsTest extends TestCase {
             'post_tag1' => "{$site_url}tags/foo/bar",
         ];
 
-        // Set the wordpress pagination base
+        // Set the WordPress pagination base
         global $wp_rewrite;
-        $wp_rewrite = (object)['pagination_base' => '/page'];
+        // @phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+        $wp_rewrite = (object) [ 'pagination_base' => '/page' ];
 
         // Set pagination to 3 posts per page
         \WP_Mock::userFunction(
@@ -52,7 +65,7 @@ final class DetectCategoryPaginationURLsTest extends TestCase {
                 'times' => 1,
                 'args' => [
                     [ 'public' => true ],
-                    'objects'
+                    'objects',
                 ],
                 'return' => $taxonomies,
             ]
@@ -65,20 +78,20 @@ final class DetectCategoryPaginationURLsTest extends TestCase {
                     'times' => 1,
                     'args' => [
                         $taxonomy->name,
-                        [ 'hide_empty' => true ]
+                        [ 'hide_empty' => true ],
                     ],
-                    'return' => $terms[$taxonomy->name],
+                    'return' => $terms[ $taxonomy->name ],
                 ]
             );
 
             // ...and the links for those terms
-            foreach ( $terms[$taxonomy->name] as $term ) {
+            foreach ( $terms[ $taxonomy->name ] as $term ) {
                 \WP_Mock::userFunction(
                     'get_term_link',
                     [
                         'times' => 1,
                         'args' => [ $term ],
-                        'return' => $term_links[$term->name],
+                        'return' => $term_links[ $term->name ],
                     ]
                 );
             }

--- a/tests/unit/DetectCategoryPaginationURLsTest.php
+++ b/tests/unit/DetectCategoryPaginationURLsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace WP2Static;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+final class DetectCategoryPaginationURLsTest extends TestCase {
+
+
+    public function testDetect() {
+        $site_url = 'https://foo.com/';
+        $taxonomies = [
+            (object)['name' => 'category'],
+            (object)['name' => 'post_tag'],
+        ];
+        $terms = [
+            'category' => [
+                'category1' => (object)['name' => 'category1', 'count' => 1],
+                'category2' => (object)['name' => 'category2', 'count' => 3],
+                'category3' => (object)['name' => 'category3', 'count' => 4],
+            ],
+            'post_tag' => [
+                'post_tag1' => (object)['name' => 'post_tag1', 'count' => 14],
+            ],
+        ];
+        $term_links = [
+            'category1' => "{$site_url}category/1",
+            'category2' => "{$site_url}category/2",
+            'category3' => "{$site_url}category/3",
+            'post_tag1' => "{$site_url}tags/foo/bar",
+        ];
+
+        // Set the wordpress pagination base
+        global $wp_rewrite;
+        $wp_rewrite = (object)['pagination_base' => '/page'];
+
+        // Set pagination to 3 posts per page
+        \WP_Mock::userFunction(
+            'get_option',
+            [
+                'times' => 1,
+                'args' => [ 'posts_per_page' ],
+                'return' => 3,
+            ]
+        );
+        // Set up our custom taxonomies
+        \WP_Mock::userFunction(
+            'get_taxonomies',
+            [
+                'times' => 1,
+                'args' => [
+                    [ 'public' => true ],
+                    'objects'
+                ],
+                'return' => $taxonomies,
+            ]
+        );
+        foreach ( $taxonomies as $taxonomy ) {
+            // And the terms within those taxonomies
+            \WP_Mock::userFunction(
+                'get_terms',
+                [
+                    'times' => 1,
+                    'args' => [
+                        $taxonomy->name,
+                        [ 'hide_empty' => true ]
+                    ],
+                    'return' => $terms[$taxonomy->name],
+                ]
+            );
+
+            // ...and the links for those terms
+            foreach ( $terms[$taxonomy->name] as $term ) {
+                \WP_Mock::userFunction(
+                    'get_term_link',
+                    [
+                        'times' => 1,
+                        'args' => [ $term ],
+                        'return' => $term_links[$term->name],
+                    ]
+                );
+            }
+        }
+
+        $expected = [
+            '/category/1/page/1',
+            '/category/2/page/1',
+            '/category/3/page/1',
+            '/category/3/page/2',
+            '/tags/foo/bar/page/1',
+            '/tags/foo/bar/page/2',
+            '/tags/foo/bar/page/3',
+            '/tags/foo/bar/page/4',
+            '/tags/foo/bar/page/5',
+        ];
+        $actual = DetectCategoryPaginationURLs::detect( $site_url );
+        $this->assertEquals( $expected, $actual );
+    }
+}

--- a/tests/unit/DetectCategoryURLsTest.php
+++ b/tests/unit/DetectCategoryURLsTest.php
@@ -6,7 +6,7 @@ use Mockery;
 use PHPUnit\Framework\TestCase;
 use WP_Mock;
 
-final class DetectCategoryPaginationURLsTest extends TestCase {
+final class DetectCategoryURLsTest extends TestCase {
 
 
     public function testDetect() {
@@ -43,11 +43,6 @@ final class DetectCategoryPaginationURLsTest extends TestCase {
             'category3' => "{$site_url}category/3",
             'post_tag1' => "{$site_url}tags/foo/bar",
         ];
-
-        // Set the WordPress pagination base
-        global $wp_rewrite;
-        // @phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-        $wp_rewrite = (object) [ 'pagination_base' => '/page' ];
 
         // Set pagination to 3 posts per page
         \WP_Mock::userFunction(
@@ -98,17 +93,12 @@ final class DetectCategoryPaginationURLsTest extends TestCase {
         }
 
         $expected = [
-            "{$site_url}category/1/page/1",
-            "{$site_url}category/2/page/1",
-            "{$site_url}category/3/page/1",
-            "{$site_url}category/3/page/2",
-            "{$site_url}tags/foo/bar/page/1",
-            "{$site_url}tags/foo/bar/page/2",
-            "{$site_url}tags/foo/bar/page/3",
-            "{$site_url}tags/foo/bar/page/4",
-            "{$site_url}tags/foo/bar/page/5",
+            "{$site_url}category/1",
+            "{$site_url}category/2",
+            "{$site_url}category/3",
+            "{$site_url}tags/foo/bar",
         ];
-        $actual = DetectCategoryPaginationURLs::detect();
+        $actual = DetectCategoryURLs::detect();
         $this->assertEquals( $expected, $actual );
     }
 }

--- a/tests/unit/DetectCommentPaginationURLsTest.php
+++ b/tests/unit/DetectCommentPaginationURLsTest.php
@@ -12,10 +12,10 @@ final class DetectCommentPaginationURLsTest extends TestCase {
     public function testDetect() {
         $site_url = 'https://foo.com/';
         $comments = [
-            (object)['comment_ID' => 1],
-            (object)['comment_ID' => 2],
-            (object)['comment_ID' => 3],
-            (object)['comment_ID' => 4],
+            (object) [ 'comment_ID' => 1 ],
+            (object) [ 'comment_ID' => 2 ],
+            (object) [ 'comment_ID' => 3 ],
+            (object) [ 'comment_ID' => 4 ],
         ];
         $comment_links = [
             // 2 comments on the same post

--- a/tests/unit/DetectCommentPaginationURLsTest.php
+++ b/tests/unit/DetectCommentPaginationURLsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace WP2Static;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+final class DetectCommentPaginationURLsTest extends TestCase {
+
+
+    public function testDetect() {
+        $site_url = 'https://foo.com/';
+        $comments = [
+            (object)['comment_ID' => 1],
+            (object)['comment_ID' => 2],
+            (object)['comment_ID' => 3],
+            (object)['comment_ID' => 4],
+        ];
+        $comment_links = [
+            // 2 comments on the same post
+            1 => "{$site_url}?p=1#comment-1",
+            2 => "{$site_url}?p=1#comment-2",
+            3 => "{$site_url}2020/10/foo#comment-3",
+            4 => "{$site_url}2020/10/bar#comment-4",
+        ];
+
+        // Create our list of custom comments
+        \WP_Mock::userFunction(
+            'get_comments',
+            [
+                'times' => 1,
+                'args' => [],
+                'return' => $comments,
+            ]
+        );
+        // And the links for them
+        foreach ( $comment_links as $comment_id => $comment_link ) {
+            \WP_Mock::userFunction(
+                'get_comment_link',
+                [
+                    'times' => 1,
+                    'args' => [ $comment_id ],
+                    'return' => $comment_link,
+                ]
+            );
+        }
+
+        // Duplicate p=1 URL removed
+        // Array keys are preserved in the output even though we don't use them.
+        // Hahstags have been stripped
+        $expected = [
+            0 => "{$site_url}?p=1",
+            2 => "{$site_url}2020/10/foo",
+            3 => "{$site_url}2020/10/bar",
+        ];
+        $actual = DetectCommentPaginationURLs::detect();
+        $this->assertEquals( $expected, $actual );
+    }
+}

--- a/tests/unit/DetectCustomPostTypeURLsTest.php
+++ b/tests/unit/DetectCustomPostTypeURLsTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace WP2Static;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+final class DetectCustomPostTypeURLsTest extends TestCase {
+
+
+    public function testDetect() {
+        global $wpdb;
+        $site_url = 'https://foo.com/';
+
+        // Create 3 attachments
+        // @phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+        $wpdb = Mockery::mock( '\WPDB' );
+        $wpdb->shouldReceive( 'get_col' )
+            ->once()
+            ->andReturn( [ 1, 2, 3 ] );
+        $wpdb->posts = 'wp_posts';
+
+        // And URLs for them
+        \WP_Mock::userFunction(
+            'get_post_permalink',
+            [
+                'times' => 1,
+                'args' => [ 1 ],
+                'return' => "{$site_url}?post_type=attachment&p=1/",
+            ]
+        );
+        \WP_Mock::userFunction(
+            'get_post_permalink',
+            [
+                'times' => 1,
+                'args' => [ 2 ],
+                'return' => "{$site_url}custom-post-type/foo/",
+            ]
+        );
+        \WP_Mock::userFunction(
+            'get_post_permalink',
+            [
+                'times' => 1,
+                'args' => [ 3 ],
+                'return' => "{$site_url}2020/10/08/bar/",
+            ]
+        );
+
+        // the attachment should not skipped
+        $expected = [
+            "{$site_url}custom-post-type/foo/",
+            "{$site_url}2020/10/08/bar/",
+        ];
+        $actual = DetectCustomPostTypeURLs::detect();
+        $this->assertEquals( $expected, $actual );
+    }
+}

--- a/tests/unit/DetectPageURLsTest.php
+++ b/tests/unit/DetectPageURLsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace WP2Static;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+final class DetectPageURLsTest extends TestCase {
+
+
+    public function testDetect() {
+        global $wpdb;
+        $site_url = 'https://foo.com/';
+
+        // Create 3 attachments
+        // @phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+        $wpdb = Mockery::mock( '\WPDB' );
+        $wpdb->shouldReceive( 'get_col' )
+            ->once()
+            ->andReturn( [ 1, 2, 3 ] );
+        $wpdb->posts = 'wp_posts';
+
+        // And URLs for them
+        for ( $i = 1; $i <= 3; $i++ ) {
+            \WP_Mock::userFunction(
+                'get_page_link',
+                [
+                    'times' => 1,
+                    'args' => [ $i ],
+                    'return' => "{$site_url}page/$i/",
+                ]
+            );
+        }
+
+        $expected = [
+            "{$site_url}page/1/",
+            "{$site_url}page/2/",
+            "{$site_url}page/3/",
+        ];
+        $actual = DetectPageURLs::detect();
+        $this->assertEquals( $expected, $actual );
+    }
+}

--- a/tests/unit/DetectPostURLsTest.php
+++ b/tests/unit/DetectPostURLsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WP2Static;
+
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use WP_Mock;
+
+final class DetectPostURLsTest extends TestCase {
+
+
+    public function testDetect() {
+        global $wpdb;
+        $site_url = 'https://foo.com/';
+
+        // Create 3 attachments
+        // @phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+        $wpdb = Mockery::mock( '\WPDB' );
+        $wpdb->shouldReceive( 'get_col' )
+            ->once()
+            ->andReturn( [ 1, 2, 3 ] );
+        $wpdb->posts = 'wp_posts';
+
+        // Mock the methods and functions used by DetectPostURLs
+        Mockery::mock( 'overload:\WP2Static\WPOverrides' )
+            ->shouldreceive( 'get_permalink' )
+            ->andReturnUsing( [ $this, 'get_permalink' ] );
+
+        $expected = [
+            'https://foo.com/2020/08/1',
+            'https://foo.com/2020/08/2',
+            'https://foo.com/2020/08/3',
+        ];
+        $actual = DetectPostURLs::detect( '%year%/%month%/%day%' );
+        $this->assertEquals( $expected, $actual );
+    }
+
+    public function get_permalink( int $post_id, string $permalink ) : string {
+        return "https://foo.com/2020/08/{$post_id}";
+    }
+}


### PR DESCRIPTION
This PR adds tests for the following detection classes:
* `DetectArchiveURLs`
* `DetectAttachmentURLs` - This isn't being used
* `DetectAuthorsURLs` - Returns URLs of authors' posts, not the author URLs
* `DetectCategoryPaginationURLs` - Returns URLs of all taxonomies, not just Categories
* `DetectCategoryURLs` - Returns URLs of all taxonomies, not just Categories
* `DetectCommentPaginationURLs` - This isn't being used
* `DetectCustomPostTypeURLs` - Returns URLs of most post types including built-in
* `DetectPageURLs`
* `DetectPostURLs` - Has some custom permalink behavior going on?

It also removes the `str_replace` found in a few of these classes which converts the output from relative to absolute URL - they'll now just return absolute URLs. The conversion to relative happens later down `URLDetector` when it calls `FilesHelper::cleanDetectedURLs` (we already have unit tests to confirm this is working - though I do have some changes I'd like to make to it but that's for another PR).

`DetectCustomPostTypeURLs`
This one returns URLs for most built-in post types - ie Post which will be duplicates of `DetectPostURLs` as well as post types in the DB but no longer in use. We should detect registered non-standard post types and return their URLs

`DetectPostURLs::detect()` was calling `WPOverrides::get_permalink()` twice for some reason resulting in URLs like *https://foo.com/https://foo.com/news/2012/12/09/my-post/*. Not sure if this has always been the case or something that's changed recently has resulted in a breakage. Removing the second call seems to have fixed the problem. Any ideas if the second call is supposed to be there?

Also do we need this custom permalink behavior? Is there a reason we use it? We just pass wordpress's permalink structure to it making its result no different to `get_permalink()` but with the added issue of needing to maintain the function. This method is only ever used in `DetectPostURLs::detect()` so we don't even use a non-standard permalink structure anywhere in the plugin.