### PR TITLE
Show sniff codes in phpcs errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "scripts": {
         "phpstan": "php -d memory_limit=-1 ./vendor/bin/phpstan analyse",
-        "phpcs": "vendor/bin/phpcs --standard=./tools/phpcs.xml --ignore=*/tests/phpstan/*,*/admin/*,**/coverage/*,*.js,*/vendor/*,*/views/*.php ./",
+        "phpcs": "vendor/bin/phpcs -s --standard=./tools/phpcs.xml --ignore=*/tests/phpstan/*,*/admin/*,**/coverage/*,*.js,*/vendor/*,*/views/*.php ./",
         "phpcompat": "vendor/bin/phpcs --standard=PHPCompatibility --runtime-set testVersion 7.3 --ignore=*/tests/*,*/admin/*,**/coverage/*,*.js,*/vendor/*,*/views/*.php ./",
         "phpcbf": "vendor/bin/phpcbf --standard=./tools/phpcs.xml --ignore=*/js/*,*/tests/*,*/admin/*,*/coverage/*,*.js,*/vendor/*,*/views/*.php ./",
         "phpunit": "vendor/bin/phpunit ./tests/unit/",


### PR DESCRIPTION
Often when I'm working on the codebase I'm getting PHPCS errors but sometimes I'll need to google or ignore them. This PR makes the process a lot easier. Example output below:

> FILE /plugins/wp2static/tests/unit/FileHelperTest.php
> FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
> 199 | WARNING | Line exceeds 100 characters; contains 112 characters (Generic.Files.LineLength.TooLong)

With the code showing I can now just add a `@phpcs:ignore Generic.Files.LineLength.TooLong` to my file without needing to remember the exact PHPCS code for that error myself.

This PR doesn't affect our git workflow or anything else - just makes developing easier.