### PR TITLE
Making fix for MySQL index limited to 1000 bytes

### DIFF
--- a/src/Addons.php
+++ b/src/Addons.php
@@ -11,11 +11,11 @@ class Addons {
         $charset_collate = $wpdb->get_charset_collate();
 
         $sql = "CREATE TABLE $table_name (
-            slug VARCHAR(255) NOT NULL,
-            type VARCHAR(255) NOT NULL,
-            name VARCHAR(255) NOT NULL,
+            slug VARCHAR(249) NOT NULL,
+            type VARCHAR(249) NOT NULL,
+            name VARCHAR(249) NOT NULL,
             docs_url VARCHAR(2083) NOT NULL,
-            description VARCHAR(255) NOT NULL,
+            description VARCHAR(249) NOT NULL,
             enabled TINYINT(1) UNSIGNED DEFAULT 0 NOT NULL,
             PRIMARY KEY  (slug)
         ) $charset_collate;";

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -28,10 +28,10 @@ class CoreOptions {
 
         $sql = "CREATE TABLE $table_name (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
-            name VARCHAR(255) NOT NULL,
-            value VARCHAR(255) NOT NULL,
-            label VARCHAR(255) NULL,
-            description VARCHAR(255) NULL,
+            name VARCHAR(249) NOT NULL,
+            value VARCHAR(249) NOT NULL,
+            label VARCHAR(249) NULL,
+            description VARCHAR(249) NULL,
             PRIMARY KEY  (id)
         ) $charset_collate;";
 


### PR DESCRIPTION
Making varchar columns 249 long (249 * 4 < 1000).

This isn't the greatest solution perhaps, since I don't know these 6 chars are really necessary for the operation. But this is what worked for me when facing this issue. 1000 bytes seems to be fairly common default for indexes in MySQL 5.6.