### PR TITLE
Fixed saving options form action

### DIFF
--- a/views/options-page.php
+++ b/views/options-page.php
@@ -244,7 +244,7 @@ function displayCheckbox($a = null, $b = null, $c = null) {
     <br>
 
     <?php wp_nonce_field( $view['nonce_action'] ); ?>
-    <input name="action" type="hidden" value="wp2staticUISaveOptions" />
+    <input name="action" type="hidden" value="wp2static_ui_save_options" />
 
     <button class="button btn-primary" type="submit">Save options</button>
 


### PR DESCRIPTION
In `src/WordPressAdmin.php` the action is defined as following:
```
add_action(
    'admin_post_wp2static_ui_save_options',
    [ 'WP2Static\Controller', 'wp2staticUISaveOptions' ],
    10,
    0
);
```

However, in this form we try to call action `admin_post_wp2staticUISaveOptions`, when
in reality it should be `admin_post_wp2static_ui_save_options`. This results in WP admin
a problem when trying to save the settings.