### PR TITLE
Post deployment actions are now run even if there are no deployment addons

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -598,8 +598,9 @@ class Controller {
                             ProcessedSite::getPath(),
                             Addons::getDeployer()
                         );
-                        do_action( 'wp2static_post_deploy_trigger', Addons::getDeployer() );
                     }
+                    WsLog::l( 'Starting post-deployment actions' );
+                    do_action( 'wp2static_post_deploy_trigger', Addons::getDeployer() );
 
                     break;
                 default:
@@ -631,8 +632,9 @@ class Controller {
         } else {
             WsLog::l( 'Starting deployment' );
             do_action( 'wp2static_deploy', ProcessedSite::getPath(), Addons::getDeployer() );
-            do_action( 'wp2static_post_deploy_trigger', Addons::getDeployer() );
         }
+        WsLog::l( 'Starting post-deployment actions' );
+        do_action( 'wp2static_post_deploy_trigger', Addons::getDeployer() );
     }
 
     public static function invalidateSingleURLCache(


### PR DESCRIPTION
See comments on issue https://github.com/WP2Static/wp2static/issues/670