### PR TITLE
Fixes "Failed to create name index on wp2static_core_options." errors

### DIFF
--- a/src/Addons.php
+++ b/src/Addons.php
@@ -11,7 +11,7 @@ class Addons {
         $charset_collate = $wpdb->get_charset_collate();
 
         $sql = "CREATE TABLE $table_name (
-            slug VARCHAR(249) NOT NULL,
+            slug VARCHAR(191) NOT NULL,
             type VARCHAR(249) NOT NULL,
             name VARCHAR(249) NOT NULL,
             docs_url VARCHAR(2083) NOT NULL,

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -28,7 +28,7 @@ class CoreOptions {
 
         $sql = "CREATE TABLE $table_name (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
-            name VARCHAR(249) NOT NULL,
+            name VARCHAR(191) NOT NULL,
             value VARCHAR(249) NOT NULL,
             label VARCHAR(249) NULL,
             description VARCHAR(249) NULL,


### PR DESCRIPTION
When using utf8mb4_unicode_ci collation, VARCHAR(254) is bigger than the MySQL Index Prefix Limit, so creating the name index fails with "SQL Error (1071): Specified key was too long; max key length is 767 bytes". VARCHAR(191) avoids that.

To be honest I'm not entirely sure why my limit is so low since I'm on InnoDB, But since the name column shouldn't contain keys that long anyway, this is a reasonable fix

Tested successfully with Wordpress 5.6.0, MariaDB 10.1.47

Additional report: https://staticword.press/t/failed-to-create-name-index-on-wpwh-wp2static-core-options/331
