### PR TITLE
fix plugin assets detection duplicating urls

### DIFF
--- a/src/DetectPluginAssets.php
+++ b/src/DetectPluginAssets.php
@@ -16,7 +16,7 @@ class DetectPluginAssets {
         $files = [];
 
         $plugins_path = SiteInfo::getPath( 'plugins' );
-        $plugins_url = SiteInfo::getUrl( 'plugins' );
+        $site_path = SiteInfo::getPath( 'site' );
 
         if ( is_dir( $plugins_path ) ) {
             $iterator = new RecursiveIteratorIterator(
@@ -55,16 +55,9 @@ class DetectPluginAssets {
 
                 $detected_filename =
                     str_replace(
-                        $plugins_path,
-                        $plugins_url,
+                        $site_path,
+                        '/',
                         $filename
-                    );
-
-                $detected_filename =
-                    str_replace(
-                        get_home_url(),
-                        '',
-                        $detected_filename
                     );
 
                 if ( is_string( $detected_filename ) ) {


### PR DESCRIPTION
I was experiencing an issue with duplicating site paths included in all detected plugin paths. To replicate this install and activate the Yoast plugin, and look at the detected urls. All plugin asset urls will not begin with "/wp-content..." and instead contain the entire site url. This is resulting in errors that are displayed during the crawl. 

Additionally this makes it so that the yoast sitemap stylesheet assets are not included, which after modifying the initial crawl list (thanks for including this filter!) the yoast sitemaps are crawled and missing the xsl styles that they reference.

This change alters the plugin asset detection to use nearly the same code to the theme asset detection.

This may be related to the duplication mentioned in this issue: https://github.com/leonstafford/wp2static/issues/751