### PR TITLE
fix getting active plugins in multisite environment

### DIFF
--- a/src/DetectPluginAssets.php
+++ b/src/DetectPluginAssets.php
@@ -29,11 +29,11 @@ class DetectPluginAssets {
             $active_plugins = get_option( 'active_plugins' );
 
             if ( is_multisite() ) {
-                $active_sitewide_plugins = get_site_option( 'active_sitewide_plugins' );
-                $active_sitewide_plugins = array_keys( $active_sitewide_plugins );
-
                 $active_plugins = array_unique(
-                    array_merge( $active_plugins, $active_sitewide_plugins )
+                    array_merge(
+                        $active_plugins,
+                        array_keys( get_site_option( 'active_sitewide_plugins' ) )
+                    )
                 );
             }
 

--- a/src/DetectPluginAssets.php
+++ b/src/DetectPluginAssets.php
@@ -28,11 +28,13 @@ class DetectPluginAssets {
 
             $active_plugins = get_option( 'active_plugins' );
 
-            if (is_multisite()) {
-                $active_sitewide_plugins = get_site_option('active_sitewide_plugins');
-                $active_sitewide_plugins = array_keys($active_sitewide_plugins);
+            if ( is_multisite() ) {
+                $active_sitewide_plugins = get_site_option( 'active_sitewide_plugins' );
+                $active_sitewide_plugins = array_keys( $active_sitewide_plugins );
 
-                $active_plugins = array_unique(array_merge($active_plugins, $active_sitewide_plugins));
+                $active_plugins = array_unique(
+                    array_merge( $active_plugins, $active_sitewide_plugins )
+                );
             }
 
             $active_plugin_dirs = array_map(

--- a/src/DetectPluginAssets.php
+++ b/src/DetectPluginAssets.php
@@ -28,6 +28,13 @@ class DetectPluginAssets {
 
             $active_plugins = get_option( 'active_plugins' );
 
+            if (is_multisite()) {
+                $active_sitewide_plugins = get_site_option('active_sitewide_plugins');
+                $active_sitewide_plugins = array_keys($active_sitewide_plugins);
+
+                $active_plugins = array_unique(array_merge($active_plugins, $active_sitewide_plugins));
+            }
+
             $active_plugin_dirs = array_map(
                 function ( $active_plugin ) {
                     return explode( '/', $active_plugin )[0];


### PR DESCRIPTION
Fixes #730

As discussed in #730 WordPress stores network active plugins of a Wordpress multisite environment in the `active_sitewide_plugins` option of the `wp_sitemeta` table. This option can be accessed using `get_site_option`.

We need to merge these plugins with the blog's active plugins in order to get a list of all active plugins for a single blog.