### PR TITLE
Fixing #751

### DIFF
--- a/src/DetectSitemapsURLs.php
+++ b/src/DetectSitemapsURLs.php
@@ -94,6 +94,12 @@ class DetectSitemapsURLs {
                     continue;
                 }
 
+                $sitemap = '/' . str_replace(
+                    $wp_site_url,
+                    '',
+                    $sitemap
+                );
+
                 $request = new Request( 'GET', $sitemap, $headers );
 
                 $response = $client->send( $request );
@@ -102,12 +108,6 @@ class DetectSitemapsURLs {
 
                 if ( $status_code === 200 ) {
                     $parser->parse( $wp_site_url . $sitemap );
-
-                    $sitemaps_urls[] = '/' . str_replace(
-                        $wp_site_url,
-                        '',
-                        $sitemap
-                    );
 
                     $extract_sitemaps = $parser->getSitemaps();
 

--- a/src/DetectSitemapsURLs.php
+++ b/src/DetectSitemapsURLs.php
@@ -83,9 +83,9 @@ class DetectSitemapsURLs {
             if ( $sitemaps === [] ) {
                 $sitemaps = [
                     // we're assigning empty arrays to match sitemaps library
-                    '/sitemap.xml' => [], // normal sitemap
-                    '/sitemap_index.xml' => [], // yoast sitemap
-                    '/wp_sitemap.xml' => [], // wp 5.5 sitemap
+                    'sitemap.xml' => [], // normal sitemap
+                    'sitemap_index.xml' => [], // yoast sitemap
+                    'wp-sitemap.xml' => [], // default WordPress sitemap
                 ];
             }
 
@@ -107,6 +107,8 @@ class DetectSitemapsURLs {
                 $status_code = $response->getStatusCode();
 
                 if ( $status_code === 200 ) {
+                    $sitemap_urls[] = $sitemap;
+
                     $parser->parse( $wp_site_url . $sitemap );
 
                     $extract_sitemaps = $parser->getSitemaps();


### PR DESCRIPTION
Hi Leon

I think that moving:
```
$sitemap = '/' . str_replace(
        $wp_site_url,
        '',
        $sitemap
    );
```
a bit higher in the code in `DetectSitemaps.php` should fix the problem with the 500 errors for sitemaps.

The error happened here:
```
$request = new Request('GET', $sitemap, $headers);
$response = $client->send($request);
```

so if there is an absolute url for a sitemap we'll hit an error here. After moving this str_replace a bit higher - everything looks ok.