### PR TITLE
Detect dead jobs and set to 'failed' status

### DIFF
--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -217,6 +217,8 @@ class ViewRenderer {
     }
 
     public static function renderJobsPage() : void {
+        JobQueue::markFailedJobs();
+
         $view = [];
         $view['nonce_action'] = 'wp2static-ui-job-options';
         $view['jobs'] = JobQueue::getJobs();

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -218,6 +218,7 @@ class ViewRenderer {
 
     public static function renderJobsPage() : void {
         JobQueue::markFailedJobs();
+        JobQueue::squashQueue();
 
         $view = [];
         $view['nonce_action'] = 'wp2static-ui-job-options';


### PR DESCRIPTION
I've only implemented this for deploy jobs since that's the only place I've seen a problem, but we could pretty easily use this pattern for every job type if needed.