### PR TITLE
Add an option to process the queue immediately after adding jobs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  - accept self-signed certs during sitemap crawling @john-shaffer
  - detect dead jobs and mark as failed @john-shaffer
  - mark duplicated waiting jobs as skipped on jobs page @john-shaffer
+ - add an option to process the queue immediately #794 @john-shaffer
 
 ## WP2Static 7.1.7
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,14 +17,17 @@ parameters:
     ignoreErrors:
         # TODO I should really develop a tiny Request Handler.
         # https://gist.github.com/nicolas-grekas/1028251#improving-native-php-interface
-        - message: '#^In method "WP2Static\\\S+::\S+", you should not use the \$_(GET|POST) superglobal#'
+        - message: '#^In method "WP2Static\\\S+::\S+", you should not use the \$_(COOKIE|GET|POST) superglobal#'
           path: src/Controller.php
-          count: 5
+          count: 6
         - message: '#^In method "WP2Static\\\S+::\S+", you should not use the \$_(GET|POST) superglobal#'
           path: src/CoreOptions.php
-          count: 19
+          count: 20
         - message: '#^In method "WP2Static\\\S+::\S+", you should not use the \$_(GET|POST) superglobal#'
           path: src/ViewRenderer.php
           count: 32
+        - message: '#^In method "WP2Static\\\S+::\S+", you should not use the \$_(GET|POST) superglobal#'
+          path: src/WordPressAdmin.php
+          count: 2
         - '/^Parameter #2 \$callable of static method WP_CLI::add_command\(\) expects callable\(\): mixed, \S+ given\.$/'
 

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -109,6 +109,14 @@ class CoreOptions {
 
         $queries[] = $wpdb->prepare(
             $query_string,
+            'processQueueImmediately',
+            '0',
+            'Process queue immediately after enqueueing jobs',
+            ''
+        );
+
+        $queries[] = $wpdb->prepare(
+            $query_string,
             'processQueueInterval',
             '0',
             'Interval to process queue with WP-Cron',
@@ -428,6 +436,7 @@ class CoreOptions {
             case 'jobs':
                 $queue_on_post_save = isset( $_POST['queueJobOnPostSave'] ) ? 1 : 0;
                 $queue_on_post_delete = isset( $_POST['queueJobOnPostDelete'] ) ? 1 : 0;
+                $process_queue_immediately = isset( $_POST['processQueueImmediately'] ) ? 1 : 0;
 
                 $wpdb->update(
                     $table_name,
@@ -439,6 +448,12 @@ class CoreOptions {
                     $table_name,
                     [ 'value' => $queue_on_post_delete ],
                     [ 'name' => 'queueJobOnPostDelete' ]
+                );
+
+                $wpdb->update(
+                    $table_name,
+                    [ 'value' => $process_queue_immediately ],
+                    [ 'name' => 'processQueueImmediately' ]
                 );
 
                 $process_queue_interval =

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -217,6 +217,7 @@ class ViewRenderer {
     }
 
     public static function renderJobsPage() : void {
+        CoreOptions::init();
         JobQueue::markFailedJobs();
         JobQueue::squashQueue();
 
@@ -227,6 +228,7 @@ class ViewRenderer {
         $view['jobOptions'] = [
             'queueJobOnPostSave' => CoreOptions::get( 'queueJobOnPostSave' ),
             'queueJobOnPostDelete' => CoreOptions::get( 'queueJobOnPostDelete' ),
+            'processQueueImmediately' => CoreOptions::get( 'processQueueImmediately' ),
             'processQueueInterval' => CoreOptions::get( 'processQueueInterval' ),
             'autoJobQueueDetection' => CoreOptions::get( 'autoJobQueueDetection' ),
             'autoJobQueueCrawling' => CoreOptions::get( 'autoJobQueueCrawling' ),

--- a/views/jobs-page.php
+++ b/views/jobs-page.php
@@ -143,6 +143,19 @@
     <br>
 
     <label
+        for="<?php echo $view['jobOptions']['processQueueImmediately']->name; ?>"
+    /><?php echo $view['jobOptions']['processQueueImmediately']->label; ?>:</label>
+
+    <input
+        type="checkbox"
+        id="<?php echo $view['jobOptions']['processQueueImmediately']->name; ?>"
+        name="<?php echo $view['jobOptions']['processQueueImmediately']->name; ?>"
+        value="1"
+        <?php echo (int) $view['jobOptions']['processQueueImmediately']->value === 1 ? 'checked' : ''; ?>
+    />
+    <br>
+
+    <label
         for=""
     />WP-Cron will attempt to process the Job Queue at this interval:</label>
 


### PR DESCRIPTION
We make a non-blocking GET request to admin-post.php to trigger the queue processing in the background. WIP as I need to replace this GET request with a POST and a nonce check.

Closes #794.