### PR TITLE
Add hostsToRewrite option and advanced-options page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
  - detect dead jobs and mark as failed @john-shaffer
  - mark duplicated waiting jobs as skipped on jobs page @john-shaffer
  - add an option to process the queue immediately #794 @john-shaffer
+ - add ability to rewrite hosts specified on a new advanced options page @john-shaffer
+  - as part of this, changed the host replacement function to use strtr instead of str_replace to avoid replacing things that we just replaced
 
 ## WP2Static 7.1.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  - add an option to process the queue immediately #794 @john-shaffer
  - add ability to rewrite hosts specified on a new advanced options page @john-shaffer
   - as part of this, changed the host replacement function to use strtr instead of str_replace to avoid replacing things that we just replaced
+ - add advanced option to skip URL rewriting @john-shaffer
 
 ## WP2Static 7.1.7
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,7 +22,7 @@ parameters:
           count: 6
         - message: '#^In method "WP2Static\\\S+::\S+", you should not use the \$_(GET|POST) superglobal#'
           path: src/CoreOptions.php
-          count: 20
+          count: 22
         - message: '#^In method "WP2Static\\\S+::\S+", you should not use the \$_(GET|POST) superglobal#'
           path: src/ViewRenderer.php
           count: 32

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -190,6 +190,7 @@ class Controller {
             'diagnostics' => [ ViewRenderer::class, 'renderDiagnosticsPage' ],
             'logs' => [ ViewRenderer::class, 'renderLogsPage' ],
             'addons' => [ ViewRenderer::class, 'renderAddonsPage' ],
+            'advanced' => [ ViewRenderer::class, 'renderAdvancedOptionsPage' ],
         ];
 
         foreach ( $submenu_pages as $slug => $method ) {
@@ -469,6 +470,17 @@ class Controller {
         if ( CoreOptions::getValue( 'queueJobOnPostDelete' ) ) {
             self::wp2staticEnqueueJobs();
         }
+    }
+
+    public static function wp2staticUISaveAdvancedOptions() : void {
+        CoreOptions::savePosted( 'advanced' );
+
+        do_action( 'wp2static_addon_ui_save_advanced_options' );
+
+        check_admin_referer( 'wp2static-ui-advanced-options' );
+
+        wp_safe_redirect( admin_url( 'admin.php?page=wp2static-advanced' ) );
+        exit;
     }
 
     public static function wp2staticEnqueueJobs() : void {

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -219,6 +219,15 @@ class CoreOptions {
         // Advanced options
 
         $queries[] = $wpdb->prepare(
+            $query_string,
+            'skipURLRewrite',
+            '0',
+            'Skip URL Rewrite',
+            'Don\'t rewrite any URLs. This may give a slight speed-up when the'
+            . ' deployment URL is the same as WordPress\'s URL.'
+        );
+
+        $queries[] = $wpdb->prepare(
             $blob_query_string,
             'hostsToRewrite',
             '1',
@@ -552,6 +561,12 @@ class CoreOptions {
 
                 break;
             case 'advanced':
+                $wpdb->update(
+                    $table_name,
+                    [ 'value' => isset( $_POST['skipURLRewrite'] ) ? 1 : 0 ],
+                    [ 'name' => 'skipURLRewrite' ]
+                );
+
                 $hosts_to_rewrite = preg_replace(
                     '/^\s+|\s+$/m',
                     '',

--- a/src/SimpleRewriter.php
+++ b/src/SimpleRewriter.php
@@ -41,6 +41,10 @@ class SimpleRewriter {
             return '';
         }
 
+        if ( (int) CoreOptions::getValue( 'skipURLRewrite' ) === 1 ) {
+            return $file_contents;
+        }
+
         $destination_url = apply_filters(
             'wp2static_set_destination_url',
             CoreOptions::getValue( 'deploymentURL' )

--- a/src/SimpleRewriter.php
+++ b/src/SimpleRewriter.php
@@ -53,22 +53,33 @@ class SimpleRewriter {
 
         $wordpress_site_url = untrailingslashit( $wordpress_site_url );
         $destination_url = untrailingslashit( $destination_url );
+        $destination_url_rel = URLHelper::getProtocolRelativeURL( $destination_url );
+        $destination_url_rel_c = addcslashes( $destination_url_rel, '/' );
 
-        $search_patterns = [
-            $wordpress_site_url,
-            URLHelper::getProtocolRelativeURL( $wordpress_site_url ),
-            addcslashes( URLHelper::getProtocolRelativeURL( $wordpress_site_url ), '/' ),
-        ];
-        $replace_patterns = [
-            $destination_url,
-            URLHelper::getProtocolRelativeURL( $destination_url ),
-            addcslashes( URLHelper::getProtocolRelativeURL( $destination_url ), '/' ),
+        $replacement_patterns = [
+            $wordpress_site_url => $destination_url,
+            URLHelper::getProtocolRelativeURL( $wordpress_site_url ) =>
+                URLHelper::getProtocolRelativeURL( $destination_url ),
+            addcslashes( URLHelper::getProtocolRelativeURL( $wordpress_site_url ), '/' ) =>
+                addcslashes( URLHelper::getProtocolRelativeURL( $destination_url ), '/' ),
         ];
 
-        $rewritten_contents = str_replace(
-            $search_patterns,
-            $replace_patterns,
-            $file_contents
+        $hosts = CoreOptions::getLineDelimitedBlobValue( 'hostsToRewrite' );
+
+        foreach ( $hosts as $host ) {
+            if ( $host ) {
+                $host_rel = URLHelper::getProtocolRelativeURL( 'http://' . $host );
+
+                $replacement_patterns[ 'http:' . $host_rel ] = $destination_url;
+                $replacement_patterns[ 'https:' . $host_rel ] = $destination_url;
+                $replacement_patterns[ $host_rel ] = $destination_url_rel;
+                $replacement_patterns[ addcslashes( $host_rel, '/' ) ] = $destination_url_rel_c;
+            }
+        }
+
+        $rewritten_contents = strtr(
+            $file_contents,
+            $replacement_patterns
         );
 
         return $rewritten_contents;

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -27,6 +27,19 @@ class ViewRenderer {
         require_once WP2STATIC_PATH . 'views/options-page.php';
     }
 
+    public static function renderAdvancedOptionsPage() : void {
+        CoreOptions::init();
+
+        $view = [];
+        $view['nonce_action'] = 'wp2static-ui-advanced-options';
+
+        $view['coreOptions'] = [
+            'hostsToRewrite' => CoreOptions::get( 'hostsToRewrite' ),
+        ];
+
+        require_once WP2STATIC_PATH . 'views/advanced-options-page.php';
+    }
+
     public static function renderDiagnosticsPage() : void {
         $view = [];
         $view['memoryLimit'] = ini_get( 'memory_limit' );

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -35,6 +35,7 @@ class ViewRenderer {
 
         $view['coreOptions'] = [
             'hostsToRewrite' => CoreOptions::get( 'hostsToRewrite' ),
+            'skipURLRewrite' => CoreOptions::get( 'skipURLRewrite' ),
         ];
 
         require_once WP2STATIC_PATH . 'views/advanced-options-page.php';

--- a/src/WordPressAdmin.php
+++ b/src/WordPressAdmin.php
@@ -205,6 +205,13 @@ class WordPressAdmin {
         );
 
         add_action(
+            'admin_post_wp2static_ui_save_advanced_options',
+            [ Controller::class, 'wp2staticUISaveAdvancedOptions' ],
+            10,
+            0
+        );
+
+        add_action(
             'admin_post_wp2static_manually_enqueue_jobs',
             [ Controller::class, 'wp2staticManuallyEnqueueJobs' ],
             10,

--- a/tests/unit/SimpleRewriterTest.php
+++ b/tests/unit/SimpleRewriterTest.php
@@ -41,7 +41,10 @@ final class SimpleRewriterTest extends TestCase {
         Mockery::mock( 'overload:\WP2Static\CoreOptions' )
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' );
+            ->andReturn( 'https://bar.com' )
+            ->shouldreceive( 'getLineDelimitedBlobValue' )
+            ->withArgs( [ 'hostsToRewrite' ] )
+            ->andReturn( [ 'localhost' ] );
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )
@@ -104,7 +107,10 @@ final class SimpleRewriterTest extends TestCase {
         Mockery::mock( 'overload:\WP2Static\CoreOptions' )
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' );
+            ->andReturn( 'https://bar.com' )
+            ->shouldreceive( 'getLineDelimitedBlobValue' )
+            ->withArgs( [ 'hostsToRewrite' ] )
+            ->andReturn( [ 'localhost' ] );
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )
@@ -124,6 +130,9 @@ final class SimpleRewriterTest extends TestCase {
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
             ->andReturn( 'https://bar.com' )
+            ->shouldreceive( 'getLineDelimitedBlobValue' )
+            ->withArgs( [ 'hostsToRewrite' ] )
+            ->andReturn( [ 'localhost' ] )
             ->getMock();
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
@@ -143,6 +152,9 @@ final class SimpleRewriterTest extends TestCase {
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
             ->andReturn( 'http://bar.com' )
+            ->shouldreceive( 'getLineDelimitedBlobValue' )
+            ->withArgs( [ 'hostsToRewrite' ] )
+            ->andReturn( [ 'localhost' ] )
             ->getMock();
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
@@ -156,6 +168,28 @@ final class SimpleRewriterTest extends TestCase {
         $this->assertEquals( $expected, $actual );
     }
 
+    public function testRewriteFileContentsHostsToRewrite() {
+        // Mock the methods and functions used by SimpleRewriter
+        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+            ->shouldreceive( 'getValue' )
+            ->withArgs( [ 'deploymentURL' ] )
+            ->andReturn( 'http://bar.com' )
+            ->shouldreceive( 'getLineDelimitedBlobValue' )
+            ->withArgs( [ 'hostsToRewrite' ] )
+            ->andReturn( [ 'localhost' ] )
+            ->getMock();
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'https://foo.com/' )
+            ->getMock();
+
+        // localhost -> bar.com
+        $expected = 'http://bar.com/somepath';
+        $actual = SimpleRewriter::rewriteFileContents( 'https://localhost/somepath' );
+        $this->assertEquals( $expected, $actual );
+    }
+
     /**
      * @dataProvider rewriteFileContentsProvider
      */
@@ -164,7 +198,10 @@ final class SimpleRewriterTest extends TestCase {
         Mockery::mock( 'overload:\WP2Static\CoreOptions' )
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' );
+            ->andReturn( 'https://bar.com' )
+            ->shouldreceive( 'getLineDelimitedBlobValue' )
+            ->withArgs( [ 'hostsToRewrite' ] )
+            ->andReturn( [ 'localhost' ] );
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )
@@ -193,7 +230,10 @@ final class SimpleRewriterTest extends TestCase {
         Mockery::mock( 'overload:\WP2Static\CoreOptions' )
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' );
+            ->andReturn( 'https://bar.com' )
+            ->shouldreceive( 'getLineDelimitedBlobValue' )
+            ->withArgs( [ 'hostsToRewrite' ] )
+            ->andReturn( [ 'localhost' ] );
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )

--- a/tests/unit/SimpleRewriterTest.php
+++ b/tests/unit/SimpleRewriterTest.php
@@ -29,6 +29,16 @@ final class SimpleRewriterTest extends TestCase {
         Mockery::close();
     }
 
+    public static function coreOptionsMock() : \Mockery\CompositeExpectation {
+        return Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+                      ->shouldReceive( 'getValue' )
+                      ->withArgs( [ 'skipURLRewrite' ] )
+                      ->andReturn( '0' )
+                      ->shouldreceive( 'getLineDelimitedBlobValue' )
+                      ->withArgs( [ 'hostsToRewrite' ] )
+                      ->andReturn( [ 'localhost' ] );
+    }
+
     /**
      * Test deleteDirWithFiles method
      *
@@ -38,13 +48,10 @@ final class SimpleRewriterTest extends TestCase {
      */
     public function testRewrite() {
         // Mock the methods and functions used by SimpleRewriter
-        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+        self::coreOptionsMock()
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' )
-            ->shouldreceive( 'getLineDelimitedBlobValue' )
-            ->withArgs( [ 'hostsToRewrite' ] )
-            ->andReturn( [ 'localhost' ] );
+            ->andReturn( 'https://bar.com' );
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )
@@ -104,13 +111,10 @@ final class SimpleRewriterTest extends TestCase {
      */
     public function testRewriteFileContents( $raw_html, $expected ) {
         // Mock the methods and functions used by SimpleRewriter
-        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+        self::coreOptionsMock()
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' )
-            ->shouldreceive( 'getLineDelimitedBlobValue' )
-            ->withArgs( [ 'hostsToRewrite' ] )
-            ->andReturn( [ 'localhost' ] );
+            ->andReturn( 'https://bar.com' );
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )
@@ -126,13 +130,10 @@ final class SimpleRewriterTest extends TestCase {
 
     public function testRewriteFileContentsHttpToHttps() {
         // Mock the methods and functions used by SimpleRewriter
-        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+        self::coreOptionsMock()
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
             ->andReturn( 'https://bar.com' )
-            ->shouldreceive( 'getLineDelimitedBlobValue' )
-            ->withArgs( [ 'hostsToRewrite' ] )
-            ->andReturn( [ 'localhost' ] )
             ->getMock();
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
@@ -148,13 +149,10 @@ final class SimpleRewriterTest extends TestCase {
 
     public function testRewriteFileContentsHttpsToHttp() {
         // Mock the methods and functions used by SimpleRewriter
-        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+        self::coreOptionsMock()
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
             ->andReturn( 'http://bar.com' )
-            ->shouldreceive( 'getLineDelimitedBlobValue' )
-            ->withArgs( [ 'hostsToRewrite' ] )
-            ->andReturn( [ 'localhost' ] )
             ->getMock();
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
@@ -168,15 +166,34 @@ final class SimpleRewriterTest extends TestCase {
         $this->assertEquals( $expected, $actual );
     }
 
-    public function testRewriteFileContentsHostsToRewrite() {
+    public function testRewriteFileContentsSkipURLRewrite() {
         // Mock the methods and functions used by SimpleRewriter
         Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+               ->shouldReceive( 'getValue' )
+               ->withArgs( [ 'skipURLRewrite' ] )
+               ->andReturn( '1' )
+               ->shouldreceive( 'getLineDelimitedBlobValue' )
+               ->withArgs( [ 'hostsToRewrite' ] )
+               ->andReturn( [ 'localhost' ] )
+               ->shouldreceive( 'getValue' )
+               ->withArgs( [ 'deploymentURL' ] )
+               ->andReturn( 'http://bar.com' );
+        Mockery::mock( 'overload:\WP2Static\SiteInfo' )
+            ->shouldreceive( 'getUrl' )
+            ->withArgs( [ 'site' ] )
+            ->andReturn( 'https://foo.com/' );
+
+        $expected = 'https://foo.com/somepath';
+        $actual = SimpleRewriter::rewriteFileContents( $expected );
+        $this->assertEquals( $expected, $actual );
+    }
+
+    public function testRewriteFileContentsHostsToRewrite() {
+        // Mock the methods and functions used by SimpleRewriter
+        self::coreOptionsMock()
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
             ->andReturn( 'http://bar.com' )
-            ->shouldreceive( 'getLineDelimitedBlobValue' )
-            ->withArgs( [ 'hostsToRewrite' ] )
-            ->andReturn( [ 'localhost' ] )
             ->getMock();
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
@@ -195,13 +212,10 @@ final class SimpleRewriterTest extends TestCase {
      */
     public function testRewriteFileContentsDestinationUrlFilter( $raw_html, $expected ) {
         // Mock the methods and functions used by SimpleRewriter
-        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+        self::coreOptionsMock()
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' )
-            ->shouldreceive( 'getLineDelimitedBlobValue' )
-            ->withArgs( [ 'hostsToRewrite' ] )
-            ->andReturn( [ 'localhost' ] );
+            ->andReturn( 'https://bar.com' );
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )
@@ -227,13 +241,10 @@ final class SimpleRewriterTest extends TestCase {
      */
     public function testRewriteFileContentsSiteUrlFilter( $raw_html, $expected ) {
         // Mock the methods and functions used by SimpleRewriter
-        Mockery::mock( 'overload:\WP2Static\CoreOptions' )
+        self::coreOptionsMock()
             ->shouldreceive( 'getValue' )
             ->withArgs( [ 'deploymentURL' ] )
-            ->andReturn( 'https://bar.com' )
-            ->shouldreceive( 'getLineDelimitedBlobValue' )
-            ->withArgs( [ 'hostsToRewrite' ] )
-            ->andReturn( [ 'localhost' ] );
+            ->andReturn( 'https://bar.com' );
         Mockery::mock( 'overload:\WP2Static\SiteInfo' )
             ->shouldreceive( 'getUrl' )
             ->withArgs( [ 'site' ] )

--- a/views/advanced-options-page.php
+++ b/views/advanced-options-page.php
@@ -22,6 +22,23 @@
             <tr>
                 <td style="width:50%;">
                     <label
+                        for="<?php echo $view['coreOptions']['skipURLRewrite']->name; ?>"
+                    ><b><?php echo $view['coreOptions']['skipURLRewrite']->label; ?></b></label>
+                    <br/><?php echo $view['coreOptions']['skipURLRewrite']->description; ?>
+                </td>
+                <td>
+                    <input
+                        id="<?php echo $view['coreOptions']['skipURLRewrite']->name; ?>"
+                        name="<?php echo $view['coreOptions']['skipURLRewrite']->name; ?>"
+                        value="1"
+                        type="checkbox"
+                        <?php echo (int) $view['coreOptions']['skipURLRewrite']->value === 1 ? 'checked' : ''; ?>
+                    />
+                </td>
+            </tr>
+            <tr>
+                <td style="width:50%;">
+                    <label
                         for="<?php echo $view['coreOptions']['hostsToRewrite']->name; ?>"
                     ><b><?php echo $view['coreOptions']['hostsToRewrite']->label; ?></b></label>
                     <br/><?php echo $view['coreOptions']['hostsToRewrite']->description; ?>

--- a/views/advanced-options-page.php
+++ b/views/advanced-options-page.php
@@ -1,0 +1,50 @@
+<?php
+// phpcs:disable Generic.Files.LineLength.MaxExceeded
+// phpcs:disable Generic.Files.LineLength.TooLong
+/**
+ * @var mixed[] $view
+ */
+
+?>
+
+<div class="wrap">
+    <form
+        name="wp2static-ui-advanced-options"
+        method="POST"
+        action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+
+    <h1>Advanced Options<h1>
+
+    <h2>Post-processing Options</h2>
+
+    <table class="widefat striped">
+        <tbody>
+            <tr>
+                <td style="width:50%;">
+                    <label
+                        for="<?php echo $view['coreOptions']['hostsToRewrite']->name; ?>"
+                    ><b><?php echo $view['coreOptions']['hostsToRewrite']->label; ?></b></label>
+                    <br/><?php echo $view['coreOptions']['hostsToRewrite']->description; ?>
+                </td>
+                <td>
+                    <textarea
+                        class="widefat"
+                        cols=30 rows=10
+                        id="<?php echo $view['coreOptions']['hostsToRewrite']->name; ?>"
+                        name="<?php echo $view['coreOptions']['hostsToRewrite']->name; ?>"
+                        type="text"
+                        ><?php echo $view['coreOptions']['hostsToRewrite']->blob_value; ?></textarea>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+
+    <p>
+
+    <?php wp_nonce_field( $view['nonce_action'] ); ?>
+    <input name="action" type="hidden" value="wp2static_ui_save_advanced_options" />
+
+    <button class="button btn-primary" type="submit">Save options</button>
+
+    </form>
+</div>


### PR DESCRIPTION
Migrate host rewriting functionality from the advanced crawling addon, with improvements.

It's useful to rewrite hosts other than the one we are crawling. Often there are links which reference a development or staging URL that we want to replace. This can also be used to rewrite http://deployment-url.com to https://deployment-url.com.

The incidental change from str_replace to strtr may fix some of the reported bugs with the host rewriting.