### PR TITLE
Added a regex replace to remove multiple // in a URI

### DIFF
--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -175,7 +175,7 @@ class SitemapParser {
     public function parse( $url, $url_content = null ) {
         $this->clean();
         $replace_pattern = '/(?<!:)\/\/+/';
-        $this->current_url = $this->urlEncode( preg_replace( $replace_pattern, '/', $url ) );
+        $this->current_url = $this->urlEncode( preg_replace( $replace_pattern, '/', $url ) ?: $url );
         if ( ! $this->urlValidate( $this->current_url ) ) {
             throw new WP2StaticException( 'Invalid URL' );
         }

--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -174,8 +174,8 @@ class SitemapParser {
      */
     public function parse( $url, $url_content = null ) {
         $this->clean();
-        $replacePattern = '/(?<!:)\/\/+/'; 
-        $this->current_url = $this->urlEncode( preg_replace($replacePattern, '/', $url ));
+        $replace_pattern = '/(?<!:)\/\/+/';
+        $this->current_url = $this->urlEncode( preg_replace( $replace_pattern, '/', $url ) );
         if ( ! $this->urlValidate( $this->current_url ) ) {
             throw new WP2StaticException( 'Invalid URL' );
         }

--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -173,10 +173,9 @@ class SitemapParser {
      * @throws WP2StaticException
      */
     public function parse( $url, $url_content = null ) {
-        $this->clean();
-        $replace_pattern = '/(?<!:)\/\/+/';
         $check_url = $url;
-        if ( $clean_url = preg_replace( $replace_pattern, '/', $url ) ) {
+        $this->clean();
+        if ( $clean_url = preg_replace( '/(?<!:)\/\/+/' , '/', $url ) ) {
             $check_url = $clean_url;
         }
         $this->current_url = $this->urlEncode( $check_url );

--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -174,7 +174,8 @@ class SitemapParser {
      */
     public function parse( $url, $url_content = null ) {
         $this->clean();
-        $this->current_url = $this->urlEncode( $url );
+        $replacePattern = '/(?<!:)\/\/+/'; 
+        $this->current_url = $this->urlEncode( preg_replace($replacePattern, '/', $url ));
         if ( ! $this->urlValidate( $this->current_url ) ) {
             throw new WP2StaticException( 'Invalid URL' );
         }

--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -175,7 +175,11 @@ class SitemapParser {
     public function parse( $url, $url_content = null ) {
         $this->clean();
         $replace_pattern = '/(?<!:)\/\/+/';
-        $this->current_url = $this->urlEncode( preg_replace( $replace_pattern, '/', $url ) ?: $url );
+        $check_url = $url;
+        if ( $clean_url = preg_replace( $replace_pattern, '/', $url ) ) {
+            $check_url = $clean_url;
+        }
+        $this->current_url = $this->urlEncode( $check_url );
         if ( ! $this->urlValidate( $this->current_url ) ) {
             throw new WP2StaticException( 'Invalid URL' );
         }


### PR DESCRIPTION
This fixes an issue where WP2Static was getting a 500 error when I had the RankMath (sitemap features) plugin activated.  The URL was trying to add http://sitename//robots.txt - which was an invalid URL and was getting a 500 error on the "404 message" (actual return code was 200) when trying to get the file.  So WP2Static was complaining about an Unhandled Exception. This update just removes any double // in the URI (excluding the http:// ).