### PR TITLE
Fix crawl redirect errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - as part of this, changed the host replacement function to use strtr instead of str_replace to avoid replacing things that we just replaced
  - add advanced option to skip URL rewriting @john-shaffer
  - fix error when a sitemap path starts with // @jhatmaker, @john-shaffer
+ - allow multiple redirects and report on redirects in wp-cli @bookwyrm, @jhatmaker
 
 ## WP2Static 7.1.7
 

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -203,11 +203,11 @@ class Crawler {
     /**
      * Crawls a string of full URL within WordPressSite
      *
-     * @throws TooManyRedirectsException
      * @return ResponseInterface|null response object
      */
     public function crawlURL( string $url ) : ?ResponseInterface {
         $headers = [];
+        $response = null;
 
         $auth_user = CoreOptions::getValue( 'basicAuthUser' );
 
@@ -224,10 +224,7 @@ class Crawler {
         try {
             $response = $this->client->send( $request );
         } catch ( TooManyRedirectsException $e ) {
-            if ( defined( 'WP_CLI' ) ) {
-                \WP_CLI::warning( "Too many redirects from $url" );
-            }
-            throw $e;
+            WsLog::l( "Too many redirects from $url" );
         }
 
         return $response;

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -203,6 +203,7 @@ class Crawler {
     /**
      * Crawls a string of full URL within WordPressSite
      *
+     * @throws TooManyRedirectsException
      * @return ResponseInterface|null response object
      */
     public function crawlURL( string $url ) : ?ResponseInterface {
@@ -222,9 +223,9 @@ class Crawler {
 
         try {
             $response = $this->client->send( $request );
-        } catch (TooManyRedirectsException $e) {
-            if ( defined('WP_CLI') ) {
-                \WP_CLI::warning("Too many redirects from $url");
+        } catch ( TooManyRedirectsException $e ) {
+            if ( defined( 'WP_CLI' ) ) {
+                \WP_CLI::warning( "Too many redirects from $url" );
             }
             throw $e;
         }

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -11,6 +11,7 @@ namespace WP2Static;
 use WP2StaticGuzzleHttp\Client;
 use WP2StaticGuzzleHttp\Psr7\Request;
 use WP2StaticGuzzleHttp\Psr7\Response;
+use WP2StaticGuzzleHttp\Exception\TooManyRedirectsException;
 use Psr\Http\Message\ResponseInterface;
 
 define( 'WP2STATIC_REDIRECT_CODES', [ 301, 302, 303, 307, 308 ] );
@@ -219,7 +220,14 @@ class Crawler {
 
         $request = new Request( 'GET', $url, $headers );
 
-        $response = $this->client->send( $request );
+        try {
+            $response = $this->client->send( $request );
+        } catch (TooManyRedirectsException $e) {
+            if ( defined('WP_CLI') ) {
+                \WP_CLI::warning("Too many redirects from $url");
+            }
+            throw $e;
+        }
 
         return $response;
     }

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -49,7 +49,7 @@ class Crawler {
                 'verify' => false,
                 'http_errors' => false,
                 'allow_redirects' => [
-                    'max' => 1,
+                    'max' => 2,
                     // required to get effective_url
                     'track_redirects' => true,
                 ],


### PR DESCRIPTION
Allow two redirect hops to support new WP instance crawl behavior.
Report on errors from too many redirects in CLI for debugging.

