### PR TITLE
Concurrently crawling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
  - [#829](https://github.com/leonstafford/wp2static/pull/829) Move options labels and definitions out of the db and into code. @john-shaffer
  - [#826](https://github.com/leonstafford/wp2static/pull/826) Allow multiple redirects and report on redirects in wp-cli. @bookwyrm, @jhatmaker
  - [28fc58e5](https://github.com/leonstafford/wp2static/commit/28fc58e5f7694129e5919530adcd6c57435391fb) Add warning-level log messages. @john-shaffer
+ - [#834](https://github.com/leonstafford/wp2static/pull/834) Implement concurrent crawling. @palmiak
+   - Deprecate Crawler::crawlURL.
 
 ## WP2Static 7.1.7 (2021-09-04)
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,7 +22,7 @@ parameters:
           count: 6
         - message: '#^In method "WP2Static\\\S+::\S+", you should not use the \$_(GET|POST) superglobal#'
           path: src/CoreOptions.php
-          count: 22
+          count: 23
         - message: '#^In method "WP2Static\\\S+::\S+", you should not use the \$_(GET|POST) superglobal#'
           path: src/ViewRenderer.php
           count: 32

--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -197,6 +197,12 @@ class CoreOptions {
 
             // Advanced options
             self::makeOptionSpec(
+                'crawlConcurrency',
+                '1',
+                'Crawl Concurrency',
+                'The maximum number of files that will be crawled at the same time.'
+            ),
+            self::makeOptionSpec(
                 'skipURLRewrite',
                 '0',
                 'Skip URL Rewrite',
@@ -599,6 +605,13 @@ VALUES (%s, %s, %s);";
 
                 break;
             case 'advanced':
+                $crawl_concurrency = intval( $_POST['crawlConcurrency'] );
+                $wpdb->update(
+                    $table_name,
+                    [ 'value' => $crawl_concurrency < 1 ? 1 : $crawl_concurrency ],
+                    [ 'name' => 'crawlConcurrency' ]
+                );
+
                 $wpdb->update(
                     $table_name,
                     [ 'value' => isset( $_POST['skipURLRewrite'] ) ? 1 : 0 ],

--- a/views/advanced-options-page.php
+++ b/views/advanced-options-page.php
@@ -22,6 +22,22 @@
             <tr>
                 <td style="width:50%;">
                     <label
+                        for="<?php echo $view['coreOptions']['crawlConcurrency']->name; ?>"
+                    ><b><?php echo $view['coreOptions']['crawlConcurrency']->label; ?></b></label>
+                    <br/><?php echo $view['coreOptions']['crawlConcurrency']->description; ?>
+                </td>
+                <td>
+                    <input
+                        id="<?php echo $view['coreOptions']['crawlConcurrency']->name; ?>"
+                        name="<?php echo $view['coreOptions']['crawlConcurrency']->name; ?>"
+                        value="<?php echo (int) $view['coreOptions']['crawlConcurrency']->value; ?>"
+                        type="number"
+                    />
+                </td>
+            </tr>
+            <tr>
+                <td style="width:50%;">
+                    <label
                         for="<?php echo $view['coreOptions']['skipURLRewrite']->name; ?>"
                     ><b><?php echo $view['coreOptions']['skipURLRewrite']->label; ?></b></label>
                     <br/><?php echo $view['coreOptions']['skipURLRewrite']->description; ?>


### PR DESCRIPTION
This is the implementation of the discussion https://github.com/leonstafford/wp2static/discussions/762

It would be great if you could take a second look.

There are some things I'm having problems with:
- there are three places that throw a warning about too long lines
- I missed this part, so this is something that should be re-add
```
try {
            $response = $this->client->send( $request );
        } catch ( TooManyRedirectsException $e ) {
            WsLog::l( "Too many redirects from $url" );
        }
```
- also `crawlURL()` method is no longer used - so we should either remove it or deprecate

Currently the concurrency rate can be set with `apply_filters( 'wp2static_concurrent_crawl_rate', 1 )` and is set to 1 as default.

I'm using the new crawler on production for WordPressowka.pl and wpowls.co.
