### PR TITLE
Fix/850

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
  - [#849](https://github.com/leonstafford/wp2static/issues/849): Make job locking work with multisite. @utchy
  - [#844](https://github.com/leonstafford/wp2static/issues/844): Fix crawling of basic auth sites. @thecodeassassin, @vladstanca
  - [#855](https://github.com/leonstafford/wp2static/issues/855): Allow setting options to empty values from the CLI. @john-shaffer
+ - [#850](https://github.com/leonstafford/wp2static/issues/850): Fix to write content to disk, even for cache hits when "Use CrawlCache" is ON. @utchy
 
 ## WP2Static 7.1.7 (2021-09-04)
 

--- a/src/CrawlCache.php
+++ b/src/CrawlCache.php
@@ -145,8 +145,6 @@ class CrawlCache {
     public static function rmUrl( string $url ) : void {
         global $wpdb;
 
-        $hashed_url = md5( $url );
-
         $table_name = $wpdb->prefix . 'wp2static_crawl_cache';
 
         $wpdb->delete(

--- a/src/CrawlQueue.php
+++ b/src/CrawlQueue.php
@@ -95,6 +95,19 @@ class CrawlQueue {
         $wpdb->query( "DELETE FROM $table_name WHERE ID IN($ids)" );
     }
 
+    public static function rmUrl( string $url ) : void {
+        global $wpdb;
+
+        $table_name = $wpdb->prefix . 'wp2static_urls';
+
+        $wpdb->delete(
+            $table_name,
+            [
+                'hashed_url' => md5( $url ),
+            ]
+        );
+    }
+
     /**
      *  Get total crawlable URLs
      *

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -155,6 +155,8 @@ class Crawler {
                     if ( $status_code === 404 ) {
                         WsLog::l( '404 for URL ' . $root_relative_path );
                         CrawlCache::rmUrl( $root_relative_path );
+                        // Delete crawl queue to prevent crawling not found urls forever.
+                        CrawlQueue::rmUrl( $root_relative_path );
                         $crawled_contents = null;
                         $is_cacheable = false;
                     } elseif ( in_array( $status_code, WP2STATIC_REDIRECT_CODES ) ) {

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -168,7 +168,7 @@ class Crawler {
                                 $prefix = trailingslashit( $deleting_path_prefix );
                                 $suffix = ltrim( $root_relative_path, '/' );
                                 $full_path = $prefix . $dir . $suffix;
-                                if ( is_link( $full_path ) ) {
+                                if ( file_exists( $full_path ) ) {
                                     unlink( $full_path );
                                 }
                             },

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -151,10 +151,12 @@ class Crawler {
                     $crawled_contents = (string) $response->getBody();
                     $status_code = $response->getStatusCode();
 
+                    $is_cacheable = true;
                     if ( $status_code === 404 ) {
                         WsLog::l( '404 for URL ' . $root_relative_path );
                         CrawlCache::rmUrl( $root_relative_path );
                         $crawled_contents = null;
+                        $is_cacheable = false;
                     } elseif ( in_array( $status_code, WP2STATIC_REDIRECT_CODES ) ) {
                         $crawled_contents = null;
                     }
@@ -208,12 +210,14 @@ class Crawler {
                         }
                     }
 
-                    CrawlCache::addUrl(
-                        $root_relative_path,
-                        $page_hash,
-                        $status_code,
-                        $redirect_to
-                    );
+                    if( $is_cacheable ) {
+                        CrawlCache::addUrl(
+                            $root_relative_path,
+                            $page_hash,
+                            $status_code,
+                            $redirect_to
+                        );
+                    }
 
                     // incrementally log crawl progress
                     if ( $this->crawled % 300 === 0 ) {

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -159,20 +159,15 @@ class Crawler {
                         CrawlQueue::rmUrl( $root_relative_path );
                         // Delete previously generated files under the directories,
                         // both the crawled and the processed.
-                        $deleting_path_prefix = apply_filters(
-                            'wp2static_deleting_path_prefix',
-                            SiteInfo::getPath( 'uploads' )
-                        );
                         array_map(
-                            function( $dir ) use ( $deleting_path_prefix, $root_relative_path ) {
-                                $prefix = trailingslashit( $deleting_path_prefix );
+                            function( $dir ) use ( $root_relative_path ) {
                                 $suffix = ltrim( $root_relative_path, '/' );
-                                $full_path = $prefix . $dir . $suffix;
+                                $full_path = trailingslashit( $dir ) . $suffix;
                                 if ( file_exists( $full_path ) && ! is_dir( $full_path ) ) {
                                     unlink( $full_path );
                                 }
                             },
-                            [ 'wp2static-crawled-site/', 'wp2static-processed-site/' ]
+                            [ StaticSite::getPath(), ProcessedSite::getPath() ]
                         );
                         $crawled_contents = null;
                         $is_cacheable = false;

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -182,16 +182,19 @@ class Crawler {
                         $page_hash = md5( (string) $status_code );
                     }
 
+                    $write_contents = true;
+
                     if ( $use_crawl_cache ) {
                         // if not already cached
                         if ( CrawlCache::getUrl( $root_relative_path, $page_hash ) ) {
                             $this->cache_hits++;
+                            $write_contents = false;
                         }
                     }
 
                     $this->crawled++;
 
-                    if ( $crawled_contents ) {
+                    if ( $crawled_contents && $write_contents) {
                         // do some magic here - naive: if URL ends in /, save to /index.html
                         // TODO: will need love for example, XML files
                         // check content type, serve .xml/rss, etc instead

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -157,6 +157,17 @@ class Crawler {
                         CrawlCache::rmUrl( $root_relative_path );
                         // Delete crawl queue to prevent crawling not found urls forever.
                         CrawlQueue::rmUrl( $root_relative_path );
+                        // Delete previously generated files under the directories both the crawled and the processed.
+                        $deleting_path_prefix =
+                            apply_filters('wp2static_deleting_path_prefix', SiteInfo::getPath('uploads'));
+                        array_map( function( $dir ) use ( $deleting_path_prefix, $root_relative_path ) {
+                            $prefix = trailingslashit($deleting_path_prefix);
+                            $suffix = ltrim($root_relative_path, '/');
+                            $full_path = $prefix . $dir . $suffix;
+                            if( is_link( $full_path ) ){
+                                unlink($full_path);
+                            }
+                        }, ['wp2static-crawled-site/', 'wp2static-processed-site/']);
                         $crawled_contents = null;
                         $is_cacheable = false;
                     } elseif ( in_array( $status_code, WP2STATIC_REDIRECT_CODES ) ) {

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -168,7 +168,7 @@ class Crawler {
                                 $prefix = trailingslashit( $deleting_path_prefix );
                                 $suffix = ltrim( $root_relative_path, '/' );
                                 $full_path = $prefix . $dir . $suffix;
-                                if ( file_exists( $full_path ) ) {
+                                if ( file_exists( $full_path ) && ! is_dir( $full_path ) ) {
                                     unlink( $full_path );
                                 }
                             },

--- a/src/Crawler.php
+++ b/src/Crawler.php
@@ -157,17 +157,23 @@ class Crawler {
                         CrawlCache::rmUrl( $root_relative_path );
                         // Delete crawl queue to prevent crawling not found urls forever.
                         CrawlQueue::rmUrl( $root_relative_path );
-                        // Delete previously generated files under the directories both the crawled and the processed.
-                        $deleting_path_prefix =
-                            apply_filters('wp2static_deleting_path_prefix', SiteInfo::getPath('uploads'));
-                        array_map( function( $dir ) use ( $deleting_path_prefix, $root_relative_path ) {
-                            $prefix = trailingslashit($deleting_path_prefix);
-                            $suffix = ltrim($root_relative_path, '/');
-                            $full_path = $prefix . $dir . $suffix;
-                            if( is_link( $full_path ) ){
-                                unlink($full_path);
-                            }
-                        }, ['wp2static-crawled-site/', 'wp2static-processed-site/']);
+                        // Delete previously generated files under the directories,
+                        // both the crawled and the processed.
+                        $deleting_path_prefix = apply_filters(
+                            'wp2static_deleting_path_prefix',
+                            SiteInfo::getPath( 'uploads' )
+                        );
+                        array_map(
+                            function( $dir ) use ( $deleting_path_prefix, $root_relative_path ) {
+                                $prefix = trailingslashit( $deleting_path_prefix );
+                                $suffix = ltrim( $root_relative_path, '/' );
+                                $full_path = $prefix . $dir . $suffix;
+                                if ( is_link( $full_path ) ) {
+                                    unlink( $full_path );
+                                }
+                            },
+                            [ 'wp2static-crawled-site/', 'wp2static-processed-site/' ]
+                        );
                         $crawled_contents = null;
                         $is_cacheable = false;
                     } elseif ( in_array( $status_code, WP2STATIC_REDIRECT_CODES ) ) {
@@ -209,7 +215,7 @@ class Crawler {
 
                     $this->crawled++;
 
-                    if ( $crawled_contents && $write_contents) {
+                    if ( $crawled_contents && $write_contents ) {
                         // do some magic here - naive: if URL ends in /, save to /index.html
                         // TODO: will need love for example, XML files
                         // check content type, serve .xml/rss, etc instead
@@ -223,7 +229,7 @@ class Crawler {
                         }
                     }
 
-                    if( $is_cacheable ) {
+                    if ( $is_cacheable ) {
                         CrawlCache::addUrl(
                             $root_relative_path,
                             $page_hash,

--- a/src/ProcessedSite.php
+++ b/src/ProcessedSite.php
@@ -14,7 +14,10 @@ use RecursiveDirectoryIterator;
 class ProcessedSite {
 
     public static function getPath() : string {
-        return SiteInfo::getPath( 'uploads' ) . 'wp2static-processed-site';
+        return apply_filters(
+            'wp2static_processed_site_path',
+            SiteInfo::getPath( 'uploads' ) . 'wp2static-processed-site'
+        );
     }
 
     /**

--- a/src/StaticSite.php
+++ b/src/StaticSite.php
@@ -34,7 +34,10 @@ class StaticSite {
     }
 
     public static function getPath() : string {
-        return SiteInfo::getPath( 'uploads' ) . 'wp2static-crawled-site';
+        return apply_filters(
+            'wp2static_crawled_site_path',
+            SiteInfo::getPath( 'uploads' ) . 'wp2static-crawled-site'
+        );
     }
 
     /**

--- a/src/ViewRenderer.php
+++ b/src/ViewRenderer.php
@@ -253,7 +253,7 @@ class ViewRenderer {
         // performance check vs map
         $disk_space = 0;
 
-        $exported_site_dir = SiteInfo::getPath( 'uploads' ) . 'wp2static-crawled-site/';
+        $exported_site_dir = StaticSite::getPath();
         if ( is_dir( $exported_site_dir ) ) {
             $files = new \RecursiveIteratorIterator(
                 new \RecursiveDirectoryIterator(
@@ -284,7 +284,7 @@ class ViewRenderer {
 
         // performance check vs map
         $disk_space = 0;
-        $processed_site_dir = SiteInfo::getPath( 'uploads' ) . 'wp2static-processed-site/';
+        $processed_site_dir = ProcessedSite::getPath();
 
         if ( is_dir( $processed_site_dir ) ) {
             $files = new \RecursiveIteratorIterator(


### PR DESCRIPTION
Fix #850 
- Skip writing content to reduce I/O write if cache exists.
- Make cache only if status code is not 404.
- Delete crawl queue from database to prevent crawling urls again, which are not found.
- Delete previously generated files under the directories both the crawled and the processed.
