### PR TITLE
re #828 skip ext reqs for CI unit tests

### DIFF
--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -43,11 +43,30 @@ jobs:
         extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
         coverage: none
 
-    - name: Validate Composer
+    - name: Validate Composer setup
       run: composer validate --strict
 
     - name: Install PHP dependencies
       run: composer install --no-interaction
 
-    - name: Run our Linter and PHPStan
-      run: composer run-script test
+    - name: Run parallel lint
+      run: composer run-script lint
+
+    - name: Test PHP Coding Standards
+      run: composer run-script phpcs
+
+    - name: Test code against PHP 7.4 standard
+      run: composer run-script php74
+
+    - name: Test code against PHP 8.0 standard
+      run: composer run-script php80
+
+    - name: Test code against PHP 8.1 standard
+      run: composer run-script php81
+
+    - name: Run PHPStan static analyser
+      run: composer run-script phpstan
+
+    - name: Run unit tests, ignoring external requests
+      run: composer run-script phpunit -- --exclude-group ExternalRequests
+

--- a/tests/unit/SitemapDownloadTest.php
+++ b/tests/unit/SitemapDownloadTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class SitemapDownloadTest extends TestCase {
 
     /**
+     * @group ExternalRequests
      * @dataProvider generateDataForTest
      * @param string $url URL
      */

--- a/tests/unit/SitemapIndexTest.php
+++ b/tests/unit/SitemapIndexTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class SitemapIndexTest extends TestCase {
 
     /**
+     * @group ExternalRequests
      * @dataProvider generateDataForTest
      * @param string $url URL
      * @param string $body URL body content

--- a/tests/unit/SitemapInvalidURLTest.php
+++ b/tests/unit/SitemapInvalidURLTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class SitemapInvalidURLTest extends TestCase {
 
     /**
+     * @group ExternalRequests
      * @dataProvider generateDataForTest
      * @param string $url URL
      */

--- a/tests/unit/SitemapRecursiveTest.php
+++ b/tests/unit/SitemapRecursiveTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class SitemapRecursiveTest extends TestCase {
 
     /**
+     * @group ExternalRequests
      * @dataProvider generateDataForTest
      * @param string $url URL
      */

--- a/tests/unit/SitemapRobotsTxtTest.php
+++ b/tests/unit/SitemapRobotsTxtTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class SitemapRobotsTxtTest extends TestCase {
 
     /**
+     * @group ExternalRequests
      * @dataProvider generateDataForTest
      * @param string $url URL
      * @param string $body URL body content

--- a/tests/unit/SitemapStrictTest.php
+++ b/tests/unit/SitemapStrictTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class SitemapStrictTest extends TestCase {
 
     /**
+     * @group ExternalRequests
      * @dataProvider generateDataForTest
      * @param string $url URL
      * @param string $body URL body content

--- a/tests/unit/SitemapStringTest.php
+++ b/tests/unit/SitemapStringTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class SitemapStringTest extends TestCase {
 
     /**
+     * @group ExternalRequests
      * @dataProvider generateDataForTest
      * @param string $url URL
      */

--- a/tests/unit/SitemapStripCommentsTest.php
+++ b/tests/unit/SitemapStripCommentsTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class SitemapStripCommentsTest extends TestCase {
 
     /**
+     * @group ExternalRequests
      * @dataProvider generateDataForTest
      * @param string $url URL
      * @param string $body URL body content

--- a/tests/unit/SitemapURLSetTest.php
+++ b/tests/unit/SitemapURLSetTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 class SitemapURLSetTest extends TestCase {
 
     /**
+     * @group ExternalRequests
      * @dataProvider generateDataForTest
      * @param string $url URL
      * @param string $body URL body content


### PR DESCRIPTION
 - granulates each composer test within GitHub Actions
 - in GH Action, runs `composer run-script phpunit -- --exclude-group ExternalRequests`
 - annotates Sitemap unit tests which make external requests with `@ExternalRequests` in order to exclude them when running on CI