### PR TITLE
Fix #240: ignore SSL errors when fetching sitemap from local site with self-signed certificate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+ - [#876](https://github.com/WP2Static/wp2static/pull/876): Fix #240: ignore SSL errors when fetching sitemap from local site with self-signed certificate. @timothylcooke
  - [d3977eab](d3977eab6be24c4985d998a7f4bf07409ef4a71b): Create an index on `wp2static_jobs.status`. @john-shaffer
  - [#785](https://github.com/leonstafford/wp2static/issues/785): Accept self-signed certs during sitemap crawling. @working-name, @john-shaffer
  - [#806](https://github.com/leonstafford/wp2static/pull/806): Detect dead jobs and mark as failed. @john-shaffer

--- a/src/SitemapParser.php
+++ b/src/SitemapParser.php
@@ -238,7 +238,7 @@ class SitemapParser {
             if ( ! isset( $this->config['guzzle']['headers']['User-Agent'] ) ) {
                 $this->config['guzzle']['headers']['User-Agent'] = $this->user_agent;
             }
-            $client = new WP2StaticGuzzleHttp\Client();
+            $client = new WP2StaticGuzzleHttp\Client( [ 'verify' => false ] );
             $res = $client->request( 'GET', $this->current_url, $this->config['guzzle'] );
             if ( $res->getStatusCode() === 200 ) {
                 return $res->getBody()->getContents();


### PR DESCRIPTION
See [this comment on issue #240](https://github.com/WP2Static/wp2static/issues/240#issuecomment-1121384577). Can confirm this fixes the issue on our `bitnami/wordpress:6` Docker image.