### PR TITLE
adds support for xsl files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .cpcache/
 .direnv/
 .lsp/
+.idea
 node_modules/
 coverage/
 admin/*.js*

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 .cpcache/
 .direnv/
 .lsp/
-.idea
 node_modules/
 coverage/
 admin/*.js*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
  - [#877](https://github.com/leonstafford/wp2static/issues/877): Detect from web UI was not adding any URLs. @timothylcooke
  - [#878](https://github.com/leonstafford/wp2static/issues/878): Fix deletion of old pages when crawl returns 404. @timothylcooke
  - [#868](https://github.com/WP2Static/wp2static/pull/868): Detect files in Divi et-cache/ directory when present. @dunklerfox
+ - [#881](https://github.com/WP2Static/wp2static/pull/881): Crawl XSL files. @vladstanca
 
 ## WP2Static 7.1.7 (2021-09-04)
 

--- a/src/FileProcessor.php
+++ b/src/FileProcessor.php
@@ -42,6 +42,9 @@ class FileProcessor {
             case 'xml':
                 do_action( 'wp2static_process_xml', $filename );
                 break;
+            case 'xsl':
+                do_action( 'wp2static_process_xsl', $filename );
+                break;
         }
     }
 }

--- a/src/WordPressAdmin.php
+++ b/src/WordPressAdmin.php
@@ -282,6 +282,13 @@ class WordPressAdmin {
         );
 
         add_action(
+            'wp2static_process_xsl',
+            [ SimpleRewriter::class, 'rewrite' ],
+            10,
+            1
+        );
+
+        add_action(
             'save_post',
             [ Controller::class, 'wp2staticSavePostHandler' ],
             0


### PR DESCRIPTION
Some plugins like All-in-One SEO add links to xsl files like sitemap.xsl so they should be processed.