### PR TITLE
Fix set $content optionnal

### DIFF
--- a/src/WordPressAdmin.php
+++ b/src/WordPressAdmin.php
@@ -424,7 +424,7 @@ class WordPressAdmin {
         wp_enqueue_script( 'wp2static_admin_scripts' );
     }
 
-    public static function wp2staticAdminFooterText( string $content ) : string {
+    public static function wp2staticAdminFooterText( ?string $content = null) : string {
         return 'Thank you for using ' .
             // @phpcs:ignore Generic.Files.LineLength.TooLong
             '<a href="https://link.strattic.com/wp2static-footer" target="_blank">WP2Static</a> by ' .


### PR DESCRIPTION
This fix the following fatal error appearing on all pages of the plugin :

```
Fatal error: Uncaught TypeError: WP2Static\WordPressAdmin::wp2staticAdminFooterText(): Argument #1 ($content) must be of type string, null given, called in /var/www/html/wp-includes/class-wp-hook.php on line 308 and defined in /var/www/html/wp-content/plugins/wp2static/src/WordPressAdmin.php:427 Stack trace: #0 /var/www/html/wp-includes/class-wp-hook.php(308): WP2Static\WordPressAdmin::wp2staticAdminFooterText(NULL) #1 /var/www/html/wp-includes/plugin.php(205): WP_Hook->apply_filters(NULL, Array) #2 /var/www/html/wp-admin/admin-footer.php(48): apply_filters('admin_footer_te...', '<span id="foote...') #3 /var/www/html/wp-admin/admin.php(297): require_once('/var/www/html/w...') #4 {main} thrown in /var/www/html/wp-content/plugins/wp2static/src/WordPressAdmin.php on line 427

```