### PR TITLE
Fix issue where queueJobOnPostSave option falls back to default unexpectedly

### DIFF
--- a/src/CoreOptions.php
+++ b/src/CoreOptions.php
@@ -404,7 +404,7 @@ VALUES (%s, %s, %s);";
 
         $option_value = $wpdb->get_var( $sql );
 
-        if ( ! $option_value || ! is_string( $option_value ) ) {
+        if ( ! is_string( $option_value ) ) {
             $option_value = (string) $opt_spec['default_value'];
         }
 


### PR DESCRIPTION
Fix issue where `queueJobOnPostSave` option falls back to default unexpectedly: #918 

- Ensure that the queueJobOnPostSave option retains its set value and does not revert to the default.
